### PR TITLE
Get rid of the LoadImageFromFile function

### DIFF
--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -44,12 +44,11 @@ AssetSuite::Manager::~Manager()
 	}
 }
 
-AssetSuite::ErrorCode AssetSuite::Manager::LoadImageFromFile(const char* filePathAndName, ImageDescriptor& imageDescriptor, std::vector<BYTE>& output)
+AssetSuite::ErrorCode AssetSuite::Manager::ImageLoadAndDecode(const char* filePathAndName, ImageDescriptor& descriptor, ImageDecoders decoder)
 {
       auto loadResult = ImageLoad(filePathAndName);
-      auto decodeResult = ImageDecode(ImageDecoders::Auto, imageDescriptor);
-      auto getResult = ImageGet(OutputFormat::RGB8, output);
-      return ErrorCode::OK;
+      auto decodeResult = ImageDecode(ImageDecoders::Auto, descriptor);
+      return decodeResult;
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::ImageLoad(const char* filePathAndName)

--- a/source/common/AssetSuite.h
+++ b/source/common/AssetSuite.h
@@ -71,27 +71,15 @@ namespace AssetSuite
 	public:
 		Manager();
 		~Manager();
-		/// <summary>
-		/// Loads image from hadr drive, decodes it and stores it in a local memory as consecutive bytes
-		/// </summary>
-		/// <param name="filePathAndName">File name, extension and path containing image to load</param>
-		/// <param name="imageDescriptor">Output structure that will contain necessary image metadata</param>
-		/// <returns>A pointer to a decoded image in the local memory as consecutive bytes</returns>
-		ErrorCode LoadImageFromFile(const char* filePathAndName, ImageDescriptor& imageDescriptor, std::vector<BYTE>& output);
-
-		// This function would take the buffer that represents the image from local memory
-		// And will store them on the hard drive
-		// This is the RAW image, meaning it has been stripped from any metadata
+		
 		void StoreImageToFile(const std::string& filePathAndName, const std::vector<BYTE>& buffer, const ImageDescriptor& imageDescriptor);
-
-		BYTE* LoadMeshFromFile(const std::string& filePathAndName, MeshDescriptor& meshDescriptor);
-
-		void StoreMeshToFile(const std::string& filePathAndName, BYTE* buffer, const MeshDescriptor& imageDescriptor);
-
+		ErrorCode ImageLoadAndDecode(const char* filePathAndName, ImageDescriptor& descriptor, ImageDecoders decoder = ImageDecoders::Auto);
 		ErrorCode ImageLoad(const char* filePathAndName);
 		ErrorCode ImageDecode(ImageDecoders decoder, ImageDescriptor& descriptor);
 		ErrorCode ImageGet(OutputFormat format, std::vector<BYTE>& output);
 
+		BYTE* LoadMeshFromFile(const std::string& filePathAndName, MeshDescriptor& meshDescriptor);
+		void StoreMeshToFile(const std::string& filePathAndName, BYTE* buffer, const MeshDescriptor& imageDescriptor);
 		ErrorCode LoadMesh();
 		ErrorCode DecodeMesh();
 		ErrorCode GetMesh();

--- a/source/demo/demo.cpp
+++ b/source/demo/demo.cpp
@@ -11,11 +11,12 @@ void main()
 
 	AssetSuite::ImageDescriptor bmpImageDesc = {};
 	std::vector<BYTE> bmpResult;
-	auto errorCode = assetManager.LoadImageFromFile("paint-01-24bpp.png", bmpImageDesc, bmpResult);
+	auto errorCode = assetManager.ImageLoadAndDecode("paint-01-24bpp.png", bmpImageDesc);
 	if (errorCode == AssetSuite::ErrorCode::NonExistingFile)
 	{
 		std::cout << "ERROR: File doesn't exist!" << std::endl;
 		return;
 	}
+	auto getErrorCode = assetManager.ImageGet(AssetSuite::OutputFormat::RGB8, bmpResult);
 	assetManager.StoreImageToFile("output.ppm", bmpResult, bmpImageDesc);
 }

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -21,7 +21,7 @@ namespace GeneralUnitTests
 			AssetSuite::Manager manager;
 
 			// This file needs to exist
-			auto error = manager.LoadImageFromFile("test_file.xyz", imageDescriptor, output);
+			auto error = manager.ImageLoadAndDecode("test_file.xyz", imageDescriptor);
 			Assert::AreEqual(true, AssetSuite::ErrorCode::FileTypeNotSupported == error);
 		}
 	};


### PR DESCRIPTION
Instead, provided a new function to load and decode image, and then separate function to get image, so I can have different output formats and potentially post processing.