### PR TITLE
Properly implement ImageGet function

### DIFF
--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -78,7 +78,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::ImageDecode(ImageDecoders decoder, Im
             {
                   decoder = ImageDecoders::PNG;
             }
-            return ErrorCode::FileTypeNotSupported;
+            else
+            {
+                  return ErrorCode::FileTypeNotSupported;
+            }
       }
 
       auto error = imageDecoders[(size_t)decoder]->Decode(decodedBuffer, rawBuffer.data(), descriptor);
@@ -87,12 +90,12 @@ AssetSuite::ErrorCode AssetSuite::Manager::ImageDecode(ImageDecoders decoder, Im
 
 AssetSuite::ErrorCode AssetSuite::Manager::ImageGet(OutputFormat format, std::vector<BYTE>& output)
 {
-      // Here you can do the formatting part (for now just copy)
-      output.resize(decodedBuffer.size());
-      for (int i = 0; i < decodedBuffer.size(); i++)
+      if (decodedBuffer.empty())
       {
-            output[i] = decodedBuffer[i];
+            return ErrorCode::DecodedBufferIsEmpty;
       }
+
+      output = decodedBuffer;
       return ErrorCode::OK;
 }
 

--- a/source/common/AssetSuite.h
+++ b/source/common/AssetSuite.h
@@ -48,6 +48,7 @@ namespace AssetSuite
 		FileTypeNotSupported = -2,
 		ColorTypeNotSupported = -3,
 		RawBufferIsEmpty = -4,
+		DecodedBufferIsEmpty = -5,
 		Undefined = -1000
 	};
 

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -32,5 +32,16 @@ namespace GeneralUnitTests
 			auto error = manager.ImageDecode(AssetSuite::ImageDecoders::Auto, imageDescriptor);
 			Assert::AreEqual(true, AssetSuite::ErrorCode::RawBufferIsEmpty == error);
 		}
+
+		TEST_METHOD(DecodedBufferIsEmpty)
+		{
+			// In this test we don't need real data
+			std::vector<BYTE> output;
+			AssetSuite::ImageDescriptor imageDescriptor;
+			AssetSuite::Manager manager;
+
+			auto error = manager.ImageGet(AssetSuite::OutputFormat::RGB8, output);
+			Assert::AreEqual(true, AssetSuite::ErrorCode::DecodedBufferIsEmpty == error);
+		}
 	};
 }


### PR DESCRIPTION
Added two new scenarios and covered it with two new unit tests. I found a new way to copy decoded buffer to the output buffer, not sure if this is indeed faster, but it takes less code.