### PR TITLE
Add proper error handling in MeshDecode

### DIFF
--- a/source/bmp/BmpDecoder.cpp
+++ b/source/bmp/BmpDecoder.cpp
@@ -1,6 +1,6 @@
 #include "BmpDecoder.h"
 
-AssetSuite::DecoderError AssetSuite::BmpDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor)
+bool AssetSuite::BmpDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor)
 {
 	BITMAPFILEHEADER fileHeader;
 	BITMAPINFOHEADER infoHeader;
@@ -50,7 +50,7 @@ AssetSuite::DecoderError AssetSuite::BmpDecoder::Decode(std::vector<BYTE>& outpu
 		}
 	}
 
-	return DecoderError::NoDecoderError;
+	return true;
 }
 
 int AssetSuite::BmpDecoder::CalculatePadding(DWORD lineSize)

--- a/source/bmp/BmpDecoder.h
+++ b/source/bmp/BmpDecoder.h
@@ -10,7 +10,7 @@ namespace AssetSuite
 	class BmpDecoder : public ImageDecoder
 	{
 	public:
-		DecoderError Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor) override;
+		bool Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor) override;
 	private:
 		int CalculatePadding(DWORD lineSize);
 	};

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -95,7 +95,7 @@ AssetSuite::ErrorCode AssetSuite::Manager::ImageDecode(ImageDecoders decoder, Im
       }
 
       auto error = imageDecoders[(size_t)decoder]->Decode(decodedBuffer, rawBuffer.data(), descriptor);
-      return (error == DecoderError::NoDecoderError) ? ErrorCode::OK : ErrorCode::ColorTypeNotSupported;
+      return (!error) ? ErrorCode::OK : ErrorCode::ColorTypeNotSupported;
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::ImageGet(OutputFormat format, std::vector<BYTE>& output)

--- a/source/common/ImageDecoder.h
+++ b/source/common/ImageDecoder.h
@@ -4,15 +4,9 @@
 
 namespace AssetSuite
 {
-	enum DecoderError
-	{
-		NoDecoderError,
-		ColorTypeNotSupported
-	};
-
 	class ImageDecoder
 	{
 	public:
-		virtual DecoderError Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor) = 0;
+		virtual bool Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor) = 0;
 	};
 }

--- a/source/common/MeshDecoder.h
+++ b/source/common/MeshDecoder.h
@@ -6,15 +6,9 @@
 
 namespace AssetSuite
 {
-	enum MeshDecoderError
-	{
-		MeshNoDecoderError,
-		MeshColorTypeNotSupported
-	};
-
 	class MeshDecoder
 	{
 	public:
-		virtual MeshDecoderError Decode(std::vector<BYTE>& output, BYTE* buffer, MeshDescriptor& descriptor) = 0;
+		virtual bool Decode(std::vector<BYTE>& output, BYTE* buffer, MeshDescriptor& descriptor) = 0;
 	};
 }

--- a/source/png/PngDecoder.cpp
+++ b/source/png/PngDecoder.cpp
@@ -4,7 +4,7 @@
 
 #define ENABLE_PRINT 0
 
-AssetSuite::DecoderError AssetSuite::PngDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor)
+bool AssetSuite::PngDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor)
 {
 	// Reset the buffers in case you  are reading multiple files
 	scanlines.clear();
@@ -53,7 +53,7 @@ AssetSuite::DecoderError AssetSuite::PngDecoder::Decode(std::vector<BYTE>& outpu
 	//}
 	if (descriptor.format == ImageFormat::Unknown)
 	{
-		return DecoderError::ColorTypeNotSupported;
+		return false;
 	}
 
 	ZLib zlib;
@@ -131,7 +131,7 @@ AssetSuite::DecoderError AssetSuite::PngDecoder::Decode(std::vector<BYTE>& outpu
 		}
 	}
 	output = filtered;
-	return DecoderError::NoDecoderError;
+	return true;
 }
 
 unsigned long AssetSuite::PngDecoder::Convert1Byte(const BYTE* buffer)

--- a/source/png/PngDecoder.h
+++ b/source/png/PngDecoder.h
@@ -90,7 +90,7 @@ namespace AssetSuite
 	class PngDecoder : public ImageDecoder
 	{
 	public:
-		DecoderError Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor) override;
+		bool Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor) override;
 	private:
 		std::vector<BYTE> compressedDataBuffer;
 		std::vector<BYTE> scanlines;

--- a/source/wavefront/ModelLoader.cpp
+++ b/source/wavefront/ModelLoader.cpp
@@ -55,7 +55,7 @@ AssetSuite::ModelLoader::~ModelLoader()
 	}
 }
 
-AssetSuite::MeshDecoderError AssetSuite::ModelLoader::Decode(std::vector<BYTE>& output, BYTE* buffer, MeshDescriptor& descriptor)
+bool AssetSuite::ModelLoader::Decode(std::vector<BYTE>& output, BYTE* buffer, MeshDescriptor& descriptor)
 {
 	// Need to reset buffers
 	Reset();
@@ -78,7 +78,7 @@ AssetSuite::MeshDecoderError AssetSuite::ModelLoader::Decode(std::vector<BYTE>& 
 		GenerateTangents();
 	}
 
-	return MeshDecoderError::MeshNoDecoderError;
+	return true;
 }
 
 void AssetSuite::ModelLoader::GenerateNormals()

--- a/source/wavefront/ModelLoader.h
+++ b/source/wavefront/ModelLoader.h
@@ -23,7 +23,7 @@ namespace AssetSuite
 	public:
 		ModelLoader();
 		~ModelLoader();
-		MeshDecoderError Decode(std::vector<BYTE>& output, BYTE* buffer, MeshDescriptor& descriptor);
+		bool Decode(std::vector<BYTE>& output, BYTE* buffer, MeshDescriptor& descriptor);
 		void GenerateNormals();
 		void GenerateTangents();
 		void DumpToFile(std::string filename);

--- a/unit_tests/BmpDecoderUnitTests.cpp
+++ b/unit_tests/BmpDecoderUnitTests.cpp
@@ -54,7 +54,7 @@ namespace BmpDecoderUnitTests
 			AssetSuite::BmpDecoder bmpDecoder;
 			std::vector<BYTE> result;
 			auto error = bmpDecoder.Decode(result, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			Assert::AreEqual((UINT)WIDTH, imageDescriptor.width);
 			Assert::AreEqual((UINT)HEIGHT, imageDescriptor.height);
@@ -116,7 +116,7 @@ namespace BmpDecoderUnitTests
 			AssetSuite::BmpDecoder bmpDecoder;
 			std::vector<BYTE> actual;
 			auto error = bmpDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			Assert::AreEqual((UINT)WIDTH, imageDescriptor.width);
 			Assert::AreEqual((UINT)HEIGHT, imageDescriptor.height);
@@ -171,7 +171,7 @@ namespace BmpDecoderUnitTests
 			AssetSuite::BmpDecoder bmpDecoder;
 			std::vector<BYTE> result;
 			auto error = bmpDecoder.Decode(result, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			Assert::AreEqual(true, AssetSuite::ImageFormat::RGB8 == imageDescriptor.format);
 		}
@@ -1734,7 +1734,7 @@ namespace BmpDecoderUnitTests
 			auto error = bmpDecoder.Decode(actual, input.data(), imageDescriptor);
 
 			// Test the metadata calculation
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 			Assert::AreEqual((UINT)64, imageDescriptor.width);
 			Assert::AreEqual((UINT)64, imageDescriptor.height);
 			Assert::AreEqual(true, AssetSuite::ImageFormat::RGB8 == imageDescriptor.format, L"Image format is incorrect");

--- a/unit_tests/PngDecoderUnitTests.cpp
+++ b/unit_tests/PngDecoderUnitTests.cpp
@@ -35,7 +35,7 @@ namespace PngDecoderUnitTests
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
 			// Expected size is 4 x 4 x 4 = 64
 			// If this is 68, then you include the first byte whish represents filtering and not thecolor
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 			Assert::AreEqual((size_t)64, actual.size());
 		}
 
@@ -63,7 +63,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 			Assert::AreEqual((UINT)4, imageDescriptor.width);
 			Assert::AreEqual((UINT)4, imageDescriptor.height);
 		}
@@ -94,7 +94,7 @@ namespace PngDecoderUnitTests
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
 			// Expected size is 4 x 4 x 4 = 64
 			// If this is 68, then you include the first byte whish represents filtering and not thecolor
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 			Assert::AreEqual(true, AssetSuite::ImageFormat::RGBA8 == imageDescriptor.format);
 		}
 
@@ -122,7 +122,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 			Assert::AreEqual((UINT)10, imageDescriptor.width);
 			Assert::AreEqual((UINT)10, imageDescriptor.height);
 			Assert::AreEqual(true, AssetSuite::ImageFormat::RGB8 == imageDescriptor.format);
@@ -160,7 +160,7 @@ namespace PngDecoderUnitTests
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
 
 			// Test the metadata calculation
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 			Assert::AreEqual((UINT)4, imageDescriptor.width);
 			Assert::AreEqual((UINT)4, imageDescriptor.height);
 			Assert::AreEqual(true, AssetSuite::ImageFormat::RGBA8 == imageDescriptor.format);
@@ -199,7 +199,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			// Test the metadata calculation
 			Assert::AreEqual((UINT)4, imageDescriptor.width);
@@ -247,7 +247,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::ColorTypeNotSupported == error);
+			Assert::AreEqual(false, error);
 		}
 
 		TEST_METHOD(PngSuite_f00n2c08)
@@ -609,7 +609,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			// Test the metadata calculation
 			Assert::AreEqual((UINT)32, imageDescriptor.width);
@@ -653,7 +653,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::ColorTypeNotSupported == error);
+			Assert::AreEqual(false , error);
 		}
 
 		TEST_METHOD(PngSuite_f01n2c08)
@@ -969,7 +969,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			// Test the metadata calculation
 			Assert::AreEqual((UINT)32, imageDescriptor.width);
@@ -1015,7 +1015,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::ColorTypeNotSupported == error);
+			Assert::AreEqual(false, error);
 		}
 
 		TEST_METHOD(PngSuite_f02n2c08)
@@ -1296,7 +1296,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			// Test the metadata calculation
 			Assert::AreEqual((UINT)32, imageDescriptor.width);
@@ -1344,7 +1344,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::ColorTypeNotSupported == error);
+			Assert::AreEqual(false, error);
 		}
 
 		TEST_METHOD(PngSuite_f03n2c08)
@@ -1632,7 +1632,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			// Test the metadata calculation
 			Assert::AreEqual((UINT)32, imageDescriptor.width);
@@ -1672,7 +1672,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::ColorTypeNotSupported == error);
+			Assert::AreEqual(false, error);
 		}
 
 		TEST_METHOD(PngSuite_f04n2c08)
@@ -1941,7 +1941,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error);
+			Assert::AreEqual(true, error);
 
 			// Test the metadata calculation
 			Assert::AreEqual((UINT)32, imageDescriptor.width);
@@ -1991,7 +1991,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::ColorTypeNotSupported == error);
+			Assert::AreEqual(false, error);
 		}
 	};
 
@@ -2019,7 +2019,7 @@ namespace PngDecoderUnitTests
 			AssetSuite::PngDecoder pngDecoder;
 			std::vector<BYTE> actual;
 			auto error = pngDecoder.Decode(actual, input.data(), imageDescriptor);
-			Assert::AreEqual(true, AssetSuite::DecoderError::NoDecoderError == error, L"Wrong error code");
+			Assert::AreEqual(true, error, L"Wrong error code");
 
 			// Test the metadata calculation
 			Assert::AreEqual((UINT)32, imageDescriptor.width);


### PR DESCRIPTION
I decided to change the Decoder interface (for both Image and Mesh) just to return Boolean, instead of specific error code. For now it is not benefitting the API at all, maybe I will change that in the future.