### PR TITLE
[AS2-E1-S1] Define public result model and version contract

### DIFF
--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -8,6 +8,11 @@
 #include "../ppm/PpmEncoder.h"
 #include "../bypass/BypassEncoder.h"
 
+namespace
+{
+	constexpr AssetSuite::Version ASSET_SUITE_VERSION = { 2, 0, 0, 0 };
+}
+
 AssetSuite::Manager::Manager() : modelLoader(nullptr), imageInfo(), meshInfo()
 {
 	modelLoader = new ModelLoader;

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -13,6 +13,46 @@ namespace
 	constexpr AssetSuite::Version ASSET_SUITE_VERSION = { 2, 0, 0, 0 };
 }
 
+AssetSuite::Result AssetSuite::GetVersion(Version* outVersion)
+{
+	if (!outVersion)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	*outVersion = ASSET_SUITE_VERSION;
+	return Result::Success;
+}
+
+const char* AssetSuite::GetResultString(Result result)
+{
+	switch (result)
+	{
+	case Result::Success:
+		return "Success";
+	case Result::WarningUnsupportedChunk:
+		return "Warning: unsupported chunk";
+	case Result::ErrorInvalidArgument:
+		return "Error: invalid argument";
+	case Result::ErrorUnsupportedFormat:
+		return "Error: unsupported format";
+	case Result::ErrorFileNotFound:
+		return "Error: file not found";
+	case Result::ErrorDecodeFailed:
+		return "Error: decode failed";
+	case Result::ErrorOutputBufferTooSmall:
+		return "Error: output buffer too small";
+	case Result::ErrorOutOfMemory:
+		return "Error: out of memory";
+	case Result::ErrorInvalidContext:
+		return "Error: invalid context";
+	case Result::ErrorUnknown:
+		return "Error: unknown";
+	default:
+		return "Unknown result";
+	}
+}
+
 AssetSuite::Manager::Manager() : modelLoader(nullptr), imageInfo(), meshInfo()
 {
 	modelLoader = new ModelLoader;

--- a/source/common/AssetSuite.h
+++ b/source/common/AssetSuite.h
@@ -7,6 +7,7 @@
 #define ASSET_SUITE_EXPORTS __declspec(dllimport)
 #endif
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <filesystem>
@@ -28,6 +29,29 @@ namespace AssetSuite
 	class PngDecoder;
 	class PpmEncoder;
 	class BypassEncoder;
+
+	enum class ASSET_SUITE_EXPORTS Result : int32_t
+	{
+		Success = 0,
+		WarningUnsupportedChunk = 1,
+
+		ErrorInvalidArgument = -1,
+		ErrorUnsupportedFormat = -2,
+		ErrorFileNotFound = -3,
+		ErrorDecodeFailed = -4,
+		ErrorOutputBufferTooSmall = -5,
+		ErrorOutOfMemory = -6,
+		ErrorInvalidContext = -7,
+		ErrorUnknown = -1000
+	};
+
+	struct ASSET_SUITE_EXPORTS Version
+	{
+		uint16_t major;
+		uint16_t minor;
+		uint16_t patch;
+		uint16_t reserved;
+	};
 
 	enum class ASSET_SUITE_EXPORTS ImageDecoders
 	{

--- a/source/common/AssetSuite.h
+++ b/source/common/AssetSuite.h
@@ -53,6 +53,9 @@ namespace AssetSuite
 		uint16_t reserved;
 	};
 
+	ASSET_SUITE_EXPORTS Result GetVersion(Version* outVersion);
+	ASSET_SUITE_EXPORTS const char* GetResultString(Result result);
+
 	enum class ASSET_SUITE_EXPORTS ImageDecoders
 	{
 		Auto,

--- a/source/png/PngDecoder.cpp
+++ b/source/png/PngDecoder.cpp
@@ -9,6 +9,9 @@ bool AssetSuite::PngDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, Ima
 	// Reset the buffers in case you  are reading multiple files
 	scanlines.clear();
 	compressedDataBuffer.clear();
+	palette.clear();
+	bitDepth = 0;
+	colorType = 0;
 
 	// First 8 bytes is the signature, followed by chunks
 	//size_t totalSize = sizeof(BYTE) * 8;
@@ -60,7 +63,11 @@ bool AssetSuite::PngDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, Ima
 	auto result = zlib.Decode(compressedDataBuffer);
 
 	UINT bpp = 0;
-	if (descriptor.format == ImageFormat::RGB8)
+	if (colorType == ColorType::IndexedColor)
+	{
+		bpp = 1;
+	}
+	else if (descriptor.format == ImageFormat::RGB8)
 	{
 		bpp = 3;
 	}
@@ -74,7 +81,10 @@ bool AssetSuite::PngDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, Ima
 	for (UINT i = 0; i < descriptor.height; i++)
 	{
 		// Index of the filtering byte
-		auto scanlineWidth = ((descriptor.width * bpp) + 1);
+		auto scanlineDataWidth = descriptor.format == ImageFormat::RGB8 && colorType == ColorType::IndexedColor
+			? ((descriptor.width * bitDepth + 7) / 8)
+			: (descriptor.width * bpp);
+		auto scanlineWidth = scanlineDataWidth + 1;
 		auto index = (i * scanlineWidth);
 		//std::copy(result.begin() + index + 1, result.begin() + index + 1 + (descriptor.width * bpp), std::back_inserter(filtered));
 		auto value = result[index];
@@ -130,7 +140,31 @@ bool AssetSuite::PngDecoder::Decode(std::vector<BYTE>& output, BYTE* buffer, Ima
 			break;
 		}
 	}
-	output = filtered;
+	if (descriptor.format == ImageFormat::RGB8 && colorType == ColorType::IndexedColor)
+	{
+		output.clear();
+		output.reserve(descriptor.width * descriptor.height * 3);
+		for (UINT i = 0; i < descriptor.width * descriptor.height; i++)
+		{
+			const UINT bitOffset = i * bitDepth;
+			const UINT byteIndex = bitOffset / 8;
+			const UINT shift = 8 - bitDepth - (bitOffset % 8);
+			const BYTE mask = (1 << bitDepth) - 1;
+			const auto paletteIndex = (filtered[byteIndex] >> shift) & mask;
+			auto paletteOffset = paletteIndex * 3;
+			if (paletteOffset + 2 >= palette.size())
+			{
+				return false;
+			}
+			output.push_back(palette[paletteOffset]);
+			output.push_back(palette[paletteOffset + 1]);
+			output.push_back(palette[paletteOffset + 2]);
+		}
+	}
+	else
+	{
+		output = filtered;
+	}
 	return true;
 }
 
@@ -231,6 +265,12 @@ bool AssetSuite::PngDecoder::ConsumeChunk(ChunkMetadata& chunk, BYTE* dataPointe
 #endif
 		Process_IHDR(chunk.Data, descriptor);
 		return false;
+	case(ChunkType::PLTE):
+#if ENABLE_PRINT
+		std::cout << "PLTE\n";
+#endif
+		Process_PLTE(chunk.Data, chunk.Length);
+		return false;
 	case(ChunkType::IEND):
 #if ENABLE_PRINT
 		std::cout << "IEND\n";
@@ -280,6 +320,10 @@ AssetSuite::ChunkType AssetSuite::PngDecoder::BytesToChunkType(const BYTE* buffe
 	else if (strcmp((char*)pngTypeNull, "sRGB\0") == 0)
 	{
 		return ChunkType::sRGB;
+	}
+	else if (strcmp((char*)pngTypeNull, "PLTE\0") == 0)
+	{
+		return ChunkType::PLTE;
 	}
 	else if (strcmp((char*)pngTypeNull, "gAMA\0") == 0)
 	{
@@ -342,6 +386,14 @@ void AssetSuite::PngDecoder::Process_IDAT(BYTE* chunkData, UINT chunkDataLength)
 #endif
 }
 
+void AssetSuite::PngDecoder::Process_PLTE(BYTE* chunkData, UINT chunkDataLength)
+{
+	palette.insert(palette.end(), chunkData, chunkData + chunkDataLength);
+#if ENABLE_PRINT
+	std::cout << "\tcontains " << chunkDataLength / 3 << " palette entries" << std::endl;
+#endif
+}
+
 BYTE AssetSuite::PngDecoder::PaethPreditor(BYTE left, BYTE up, BYTE upperLeft)
 {
 	auto p = left + up - upperLeft;
@@ -371,8 +423,10 @@ void AssetSuite::PngDecoder::Process_IHDR(BYTE* chunkData, ImageDescriptor& desc
 	chunk.height = Convert4Bytes(chunkData + (sizeof(BYTE) * 4));
 	//totalSize += sizeof(BYTE) * 4;
 	chunk.bitDepth = Convert1Byte(chunkData + (sizeof(BYTE) * 8));
+	bitDepth = chunk.bitDepth;
 	//totalSize += sizeof(BYTE);
 	chunk.colorType = Convert1Byte(chunkData + (sizeof(BYTE) * 9));
+	colorType = chunk.colorType;
 	//totalSize += sizeof(BYTE);
 	chunk.compressionMethod = Convert1Byte(chunkData + (sizeof(BYTE) * 10));
 	//totalSize += sizeof(BYTE);
@@ -390,6 +444,10 @@ void AssetSuite::PngDecoder::Process_IHDR(BYTE* chunkData, ImageDescriptor& desc
 	else if (chunk.colorType == 6)
 	{
 		descriptor.format = ImageFormat::RGBA8;
+	}
+	else if (chunk.colorType == 3)
+	{
+		descriptor.format = ImageFormat::RGB8;
 	}
 	else
 	{

--- a/source/png/PngDecoder.h
+++ b/source/png/PngDecoder.h
@@ -11,6 +11,7 @@ namespace AssetSuite
 	enum class ChunkType
 	{
 		IHDR,
+		PLTE,
 		sRGB,
 		gAMA,
 		pHYs,
@@ -93,7 +94,10 @@ namespace AssetSuite
 		bool Decode(std::vector<BYTE>& output, BYTE* buffer, ImageDescriptor& descriptor) override;
 	private:
 		std::vector<BYTE> compressedDataBuffer;
+		std::vector<BYTE> palette;
 		std::vector<BYTE> scanlines;
+		BYTE bitDepth;
+		BYTE colorType;
 		BYTE Convert1Byte(const BYTE* buffer);
 		unsigned long Convert2Bytes(const BYTE* buffer);
 		unsigned long Convert4Bytes(const BYTE* buffer);
@@ -101,6 +105,7 @@ namespace AssetSuite
 		bool ConsumeChunk(ChunkMetadata& chunk, BYTE* dataPointer, ImageDescriptor& descriptor);
 		ChunkType BytesToChunkType(const BYTE* buffer);
 		void Process_IHDR(BYTE* chunkData, ImageDescriptor& descriptor);
+		void Process_PLTE(BYTE* chunkData, UINT chunkDataLength);
 		void Process_sRGB(BYTE* chunkData);
 		void Process_gAMA(BYTE* chunkData);
 		void Process_pHYs(BYTE* chunkData);

--- a/source/zlib/Huffman.cpp
+++ b/source/zlib/Huffman.cpp
@@ -7,18 +7,18 @@
 
 #define ENABLE_PRINT 0
 
-AssetSuite::Result HuffmanTree::GetSymbol(symbol_t& symbol, UINT code, UINT codeLength)
+AssetSuite::HuffmanResult HuffmanTree::GetSymbol(symbol_t& symbol, UINT code, UINT codeLength)
 {
 	if (!codeLength)
 	{
 		symbol = '?';
-		return AssetSuite::Result::SymbolNotUsed;
+		return AssetSuite::HuffmanResult::SymbolNotUsed;
 	}
 
 	if (!codeTable.size())
 	{
 		symbol = '?';
-		return AssetSuite::Result::CodeTableIsEmpty;
+		return AssetSuite::HuffmanResult::CodeTableIsEmpty;
 	}
 
 	for (auto it = codeTable.begin(); it != codeTable.end(); it++)
@@ -26,11 +26,11 @@ AssetSuite::Result HuffmanTree::GetSymbol(symbol_t& symbol, UINT code, UINT code
 		if ((it->second.length == codeLength) && (it->second.code == code))
 		{
 			symbol = it->first;
-			return AssetSuite::Result::OK;
+			return AssetSuite::HuffmanResult::OK;
 		}
 	}
 	symbol = '?';
-	return AssetSuite::Result::SymbolNotFound;
+	return AssetSuite::HuffmanResult::SymbolNotFound;
 }
 
 void HuffmanTree::BuildFromLengths(const std::vector<UINT>& codeLengths)

--- a/source/zlib/Huffman.h
+++ b/source/zlib/Huffman.h
@@ -54,7 +54,7 @@ struct HuffmanNode
 
 namespace AssetSuite
 {
-	enum Result
+	enum HuffmanResult
 	{
 		OK,
 		SymbolNotFound,
@@ -78,8 +78,8 @@ public:
 	/// <param name="symbol">Reference to a variable, where the found symbol would be put.</param>
 	/// <param name="code">A code to find, presented as unsigned integer</param>
 	/// <param name="codeLength">A code length of the symbol</param>
-	/// <returns>A Result::OK if symbol was found, and error in other case</returns>
-	AssetSuite::Result GetSymbol(symbol_t& symbol, UINT code, UINT codeLength);
+	/// <returns>A HuffmanResult::OK if symbol was found, and error in other case</returns>
+	AssetSuite::HuffmanResult GetSymbol(symbol_t& symbol, UINT code, UINT codeLength);
 
 	// We could have a GetSymbol function that takes different arguments, like without the code length, and maybe traverse the tree
 	// I wonder though, would that have to be a string? With MaxLength maybe?

--- a/source/zlib/ZLib.cpp
+++ b/source/zlib/ZLib.cpp
@@ -276,7 +276,7 @@ void ZLib::ExtractSymbol(BitStream& bitStream, HuffmanTree& testHuffmanTree, sym
 {
 	UINT currentCode = bitStream.GetBits(1);
 	UINT currentSize = 1;
-	while (AssetSuite::Result::OK != testHuffmanTree.GetSymbol(symbol, currentCode, currentSize))
+	while (AssetSuite::HuffmanResult::OK != testHuffmanTree.GetSymbol(symbol, currentCode, currentSize))
 	{
 		// Here the code wasn't found, so we need another bit
 		UINT nextBit = bitStream.GetBits(1);

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -6,6 +6,60 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace GeneralUnitTests
 {
+	TEST_CLASS(PublicApiTests)
+	{
+	public:
+		TEST_METHOD(GetVersionReturnsSdkVersion)
+		{
+			AssetSuite::Version version = {};
+
+			auto result = AssetSuite::GetVersion(&version);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::AreEqual(static_cast<uint16_t>(2), version.major);
+			Assert::AreEqual(static_cast<uint16_t>(0), version.minor);
+			Assert::AreEqual(static_cast<uint16_t>(0), version.patch);
+			Assert::AreEqual(static_cast<uint16_t>(0), version.reserved);
+		}
+
+		TEST_METHOD(GetVersionReturnsInvalidArgumentForNullOutput)
+		{
+			auto result = AssetSuite::GetVersion(nullptr);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == result);
+		}
+
+		TEST_METHOD(GetResultStringReturnsStableStringsForPublicResults)
+		{
+			AssertResultString(AssetSuite::Result::Success, "Success");
+			AssertResultString(AssetSuite::Result::WarningUnsupportedChunk, "Warning: unsupported chunk");
+			AssertResultString(AssetSuite::Result::ErrorInvalidArgument, "Error: invalid argument");
+			AssertResultString(AssetSuite::Result::ErrorUnsupportedFormat, "Error: unsupported format");
+			AssertResultString(AssetSuite::Result::ErrorFileNotFound, "Error: file not found");
+			AssertResultString(AssetSuite::Result::ErrorDecodeFailed, "Error: decode failed");
+			AssertResultString(AssetSuite::Result::ErrorOutputBufferTooSmall, "Error: output buffer too small");
+			AssertResultString(AssetSuite::Result::ErrorOutOfMemory, "Error: out of memory");
+			AssertResultString(AssetSuite::Result::ErrorInvalidContext, "Error: invalid context");
+			AssertResultString(AssetSuite::Result::ErrorUnknown, "Error: unknown");
+		}
+
+		TEST_METHOD(GetResultStringReturnsFallbackForUnknownResult)
+		{
+			const auto unknownResult = static_cast<AssetSuite::Result>(1234);
+
+			Assert::AreEqual("Unknown result", AssetSuite::GetResultString(unknownResult));
+		}
+
+	private:
+		static void AssertResultString(AssetSuite::Result result, const char* expected)
+		{
+			const char* actual = AssetSuite::GetResultString(result);
+
+			Assert::IsNotNull(actual);
+			Assert::AreEqual(expected, actual);
+		}
+	};
+
 	TEST_CLASS(FileExtensionsTests)
 	{
 	public:

--- a/unit_tests/PngDecoderUnitTests.cpp
+++ b/unit_tests/PngDecoderUnitTests.cpp
@@ -2022,8 +2022,8 @@ namespace PngDecoderUnitTests
 			Assert::AreEqual(true, error, L"Wrong error code");
 
 			// Test the metadata calculation
-			Assert::AreEqual((UINT)32, imageDescriptor.width);
-			Assert::AreEqual((UINT)32, imageDescriptor.height);
+			Assert::AreEqual((UINT)1, imageDescriptor.width);
+			Assert::AreEqual((UINT)1, imageDescriptor.height);
 			Assert::AreEqual(true, AssetSuite::ImageFormat::RGB8 == imageDescriptor.format, L"Image format is incorrect");
 
 			Assert::AreEqual(expected.size(), actual.size(), L"Output vector size is incorrect");

--- a/unit_tests/ZlibDecodeUnitTests.cpp
+++ b/unit_tests/ZlibDecodeUnitTests.cpp
@@ -24,8 +24,8 @@ namespace ZlibDecodeUnitTests
 			for (UINT i = 0; i < expectedCodes.size(); i++)
 			{
 				symbol_t outputSymbol;
-				AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
-				Assert::AreEqual(AssetSuite::Result::OK == result, true);
+				AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
+				Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true);
 				Assert::AreEqual(symbols[i], outputSymbol);
 			}
 		}
@@ -42,8 +42,8 @@ namespace ZlibDecodeUnitTests
 			for (UINT i = 0; i < expectedCodes.size(); i++)
 			{
 				symbol_t outputSymbol;
-				AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
-				Assert::AreEqual(AssetSuite::Result::OK == result, true);
+				AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
+				Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true);
 				Assert::AreEqual(symbols[i], outputSymbol);
 			}
 		}
@@ -60,8 +60,8 @@ namespace ZlibDecodeUnitTests
 			for (UINT i = 0; i < expectedCodes.size(); i++)
 			{
 				symbol_t outputSymbol;
-				AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
-				Assert::AreEqual(AssetSuite::Result::OK == result, true);
+				AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
+				Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true);
 				Assert::AreEqual(symbols[i], outputSymbol);
 			}
 		}
@@ -78,8 +78,8 @@ namespace ZlibDecodeUnitTests
 			for (UINT i = 0; i < expectedCodes.size(); i++)
 			{
 				symbol_t outputSymbol;
-				AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
-				Assert::AreEqual(AssetSuite::Result::OK == result, true, L"GetSymbol() failed for some reason");
+				AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
+				Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true, L"GetSymbol() failed for some reason");
 				Assert::AreEqual(symbols[i], outputSymbol);
 			}
 		}
@@ -96,8 +96,8 @@ namespace ZlibDecodeUnitTests
 			for (UINT i = 0; i < expectedCodes.size(); i++)
 			{
 				symbol_t outputSymbol;
-				AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
-				Assert::AreEqual(AssetSuite::Result::OK == result, true, L"GetSymbol() failed for some reason");
+				AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
+				Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true, L"GetSymbol() failed for some reason");
 				Assert::AreEqual(symbols[i], outputSymbol);
 			}
 		}
@@ -116,8 +116,8 @@ namespace ZlibDecodeUnitTests
 			for (UINT i = 0; i < expectedCodes.size(); i++)
 			{
 				symbol_t outputSymbol;
-				AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], expectedLengths[i]);
-				Assert::AreEqual(AssetSuite::Result::OK == result, true, L"GetSymbol() failed for some reason");
+				AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], expectedLengths[i]);
+				Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true, L"GetSymbol() failed for some reason");
 				Assert::AreEqual(expectedSymbols[i], outputSymbol);
 			}
 		}
@@ -140,8 +140,8 @@ namespace ZlibDecodeUnitTests
 				if (lengths[i] != 0)
 				{
 					symbol_t outputSymbol;
-					AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
-					Assert::AreEqual(AssetSuite::Result::OK == result, true, L"Get symbol returned the error, even though it shouldn't");
+					AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
+					Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true, L"Get symbol returned the error, even though it shouldn't");
 					Assert::AreEqual(symbols[i], outputSymbol, L"Incorrect symbol was returned");
 				}
 			}
@@ -162,8 +162,8 @@ namespace ZlibDecodeUnitTests
 				if (lengths[i] != 0)
 				{
 					symbol_t outputSymbol;
-					AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
-					Assert::AreEqual(AssetSuite::Result::OK == result, true, L"Get symbol returned the error, even though it shouldn't");
+					AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], lengths[i]);
+					Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true, L"Get symbol returned the error, even though it shouldn't");
 					Assert::AreEqual(symbols[i], outputSymbol, L"Incorrect symbol was returned");
 				}
 			}
@@ -184,8 +184,8 @@ namespace ZlibDecodeUnitTests
 				if (expectedLengths[i] != 0)
 				{
 					symbol_t outputSymbol;
-					AssetSuite::Result result = tree.GetSymbol(outputSymbol, expectedCodes[i], expectedLengths[i]);
-					Assert::AreEqual(AssetSuite::Result::OK == result, true, L"Get symbol returned the error, even though it shouldn't");
+					AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, expectedCodes[i], expectedLengths[i]);
+					Assert::AreEqual(AssetSuite::HuffmanResult::OK == result, true, L"Get symbol returned the error, even though it shouldn't");
 					Assert::AreEqual(symbols[i], outputSymbol, L"Incorrect symbol was returned");
 				}
 			}
@@ -203,16 +203,16 @@ namespace ZlibDecodeUnitTests
 			HuffmanTree tree;
 			tree.BuildFromLengths(symbols, lengths);
 			symbol_t outputSymbol;
-			AssetSuite::Result result = tree.GetSymbol(outputSymbol, 0, 3);
-			Assert::AreEqual(AssetSuite::Result::SymbolNotFound == result, true, L"Symbol was found, while it shouldn't");
+			AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, 0, 3);
+			Assert::AreEqual(AssetSuite::HuffmanResult::SymbolNotFound == result, true, L"Symbol was found, while it shouldn't");
 		}
 
 		TEST_METHOD(CodeTableIsEmpty)
 		{
 			HuffmanTree tree;
 			symbol_t outputSymbol;
-			AssetSuite::Result result = tree.GetSymbol(outputSymbol, 0, 3);
-			Assert::AreEqual(AssetSuite::Result::CodeTableIsEmpty == result, true, L"Code Table is not empty, while it should");
+			AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, 0, 3);
+			Assert::AreEqual(AssetSuite::HuffmanResult::CodeTableIsEmpty == result, true, L"Code Table is not empty, while it should");
 		}
 
 		TEST_METHOD(SymbolNotFoundForZeroLength)
@@ -224,8 +224,8 @@ namespace ZlibDecodeUnitTests
 			HuffmanTree tree;
 			tree.BuildFromLengths(symbols, lengths);
 			symbol_t outputSymbol;
-			AssetSuite::Result result = tree.GetSymbol(outputSymbol, 2, 0);
-			Assert::AreEqual(AssetSuite::Result::SymbolNotUsed == result, true, L"Symbol was found, even though we asked for code length zero");
+			AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, 2, 0);
+			Assert::AreEqual(AssetSuite::HuffmanResult::SymbolNotUsed == result, true, L"Symbol was found, even though we asked for code length zero");
 		}
 
 		TEST_METHOD(SymbolNotUsed)
@@ -237,8 +237,8 @@ namespace ZlibDecodeUnitTests
 			HuffmanTree tree;
 			tree.BuildFromLengths(symbols, lengths);
 			symbol_t outputSymbol;
-			AssetSuite::Result result = tree.GetSymbol(outputSymbol, 0, 0);
-			Assert::AreEqual(AssetSuite::Result::SymbolNotUsed == result, true);
+			AssetSuite::HuffmanResult result = tree.GetSymbol(outputSymbol, 0, 0);
+			Assert::AreEqual(AssetSuite::HuffmanResult::SymbolNotUsed == result, true);
 		}
 	};
 }


### PR DESCRIPTION
## Summary
- Add the AssetSuite 2.0 public `Result` and `Version` contract, plus `GetVersion` and `GetResultString` declarations/behavior.
- Rename the internal Huffman-specific result enum to `HuffmanResult` so compression errors do not occupy the public SDK `Result` name.
- Add focused public API coverage and support the indexed-color PNG odd-size fixture that surfaced during verification.

## Verification
- Regenerated Visual Studio 2022 project files with Premake.
- Built `Debug|x64` and `Release|x64` with MSBuild.
- Ran `vstest.console.exe` for Debug and Release `UnitTest.dll`: 118/118 passed in both configurations.