### PR TITLE
[codex] Enforce public SDK header hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,95 @@
 # AssetSuite
-## Overview
-A simple and convinient library for loading game assets (like images and meshes) from disc to local memory.It's main design principle is that it has to be both convinient to use and easy to read and understand, and not necessarily extremly fast. You should use this library if you simply want to get your work done on your engine and don't care about the details, or if you are studying image formats like BMP or PNG.
 
-## Dependencies
-The library requires C++17 because it uses the `filesystem` header. It also requires C++20 because of the `span` usage.
+## Overview
+
+AssetSuite is a C++ asset loading SDK for image and mesh data. The 2.0 SDK surface is designed as a small public boundary for engine and tool integration: consumers include stable public headers, receive SDK result codes, and exchange plain descriptor structs and opaque handles instead of internal implementation classes.
+
+## Public SDK Surface
+
+External consumers should include the 2.0 public header from the installed include root:
+
+```cpp
+#include <AssetSuite/AssetSuite.h>
+```
+
+The public headers are provided under `include/AssetSuite` and are installed under `inc/AssetSuite`. They define:
+
+- `AssetSuite::Result` and `AssetSuite::Version`
+- `AssetSuite::GetVersion` and `AssetSuite::GetResultString`
+- opaque handle types such as `AssetSuite::ContextHandle`, `AssetSuite::BlobHandle`, `AssetSuite::ImageHandle`, and `AssetSuite::MeshHandle`
+- plain descriptor structs such as `AssetSuite::ContextDesc`, `AssetSuite::BlobDesc`, `AssetSuite::ImageDesc`, and `AssetSuite::MeshDesc`
+- SDK enums such as `AssetSuite::AssetFormat`, `AssetSuite::PixelFormat`, and `AssetSuite::MeshAttributeFlags`
+
+Public headers do not require `Windows.h`, STL containers, filesystem path types, or internal implementation classes.
 
 ## Usage
-First of all, you need to declare Asset Suite manager. Asset Suite manages its memory internally, so once this class goes out of scope, the memory will be cleared.
-```cpp
-AssetSuite::Manager assetManager;
-```
-Then you need to load and decode image or mesh from the disc, to the memory. By default, the appropriate decoder will be used based on the file extension, however, you can provide an option which decoder to use. You can either use two different functions or a convinent one that does both of those things.
-```cpp
-auto errorCode = assetManager.ImageLoadAndDecode("girl_with_pearl_earring.bmp");
-```
-Finally, you need to retrieve the image from memory. You can do that by using the `Get` function. You need to provide the output format of the image, as well as a vector of bytes where the output will be copied to. You will also get some information about the image in the `ImageDescriptor`, like image dimensions.
-```cpp
-AssetSuite::ImageDescriptor imageDescriptor = {};
-std::vector<BYTE> imageOutput;
-errorCode = assetManager.ImageGet(AssetSuite::OutputFormat::RGB8, imageOutput, imageDescriptor);
-```
-The procedure is very similar for meshes, but when you get one, you need to provide the name of the mesh as well, since usually you can have multiple meshes in one file.
-```cpp
-errorCode = assetManager.MeshLoadAndDecode("wavefront_sample.obj");
 
-std::vector<FLOAT> meshOutput;
-AssetSuite::MeshDescriptor meshDescriptor;
-errorCode = assetManager.MeshGet("Plane_Plane\r", AssetSuite::MeshOutputFormat::POSITION, meshOutput, meshDescriptor);
+The current 2.0 public SDK headers expose the stable type and version contract used by external consumers:
+
+```cpp
+#include <AssetSuite/AssetSuite.h>
+
+#include <cstdint>
+
+int main()
+{
+	AssetSuite::Version version = {};
+	AssetSuite::Result result = AssetSuite::GetVersion(&version);
+
+	if (result != AssetSuite::Result::Success)
+	{
+		const char* message = AssetSuite::GetResultString(result);
+		return message != nullptr ? 1 : 2;
+	}
+
+	AssetSuite::ContextHandle context = nullptr;
+	AssetSuite::BlobHandle blob = nullptr;
+	AssetSuite::ImageHandle image = nullptr;
+	AssetSuite::MeshHandle mesh = nullptr;
+
+	AssetSuite::ContextDesc contextDesc = { sizeof(AssetSuite::ContextDesc), 0 };
+	AssetSuite::BlobDesc blobDesc = {
+		sizeof(AssetSuite::BlobDesc),
+		0,
+		AssetSuite::AssetFormat::Unknown,
+		0
+	};
+	AssetSuite::ImageDesc imageDesc = {
+		sizeof(AssetSuite::ImageDesc),
+		0,
+		0,
+		AssetSuite::PixelFormat::Unknown,
+		0,
+		0
+	};
+	AssetSuite::MeshDesc meshDesc = {
+		sizeof(AssetSuite::MeshDesc),
+		0,
+		0,
+		0,
+		static_cast<uint32_t>(AssetSuite::MeshAttributeFlags::None)
+	};
+
+	return context || blob || image || mesh ||
+		contextDesc.structSize == 0 ||
+		blobDesc.structSize == 0 ||
+		imageDesc.structSize == 0 ||
+		meshDesc.structSize == 0;
+}
 ```
+
+Asset loading entry points will build on these handle and descriptor types as the 2.0 API is expanded.
 
 ## Integration
-This library provides two sets of DLLs and LIBs, one for Release and one for Debug configuration. This is important, since this library uses STL, and having one DLL would lead to errors. There is also a set of common headers that need to be included.
 
-## AssetSuite 2.0 SDK Headers
-The AssetSuite 2.0 public SDK surface is being introduced under `include/AssetSuite`.
-External consumers should include `<AssetSuite/AssetSuite.h>` from that public include root. These headers define the SDK-facing result/version contract, opaque handles, and plain descriptor structs without requiring `Windows.h`, STL containers, or internal implementation headers.
+Build the project with Premake-generated Visual Studio projects. The package output contains Debug and Release binaries plus the public SDK headers under `bin/<Config>/inc/AssetSuite`.
+
+The installed public header surface is validated by `PublicHeaderCompile`, which compiles an external-consumer translation unit and checks that installed headers do not expose platform-specific, legacy, or STL-owning API types.
 
 ## Installation
-The library could be built from the source using Premake (I find it much easier and intuitive then CMake) or you can use pre-built binaries provided with the release.
+
+AssetSuite can be built from source using Premake or consumed from release artifacts when available.
 
 ## License
+
 This library is provided as is, and it uses the MIT license.

--- a/premake5.lua
+++ b/premake5.lua
@@ -7,6 +7,7 @@ CREATE_PUBLIC_INC_DIRECTORY = "{MKDIR} %{cfg.targetdir}/../inc/AssetSuite"
 COPY_RELEASE_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_r.lib %{cfg.targetdir}/../lib"
 COPY_DEBUG_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_d.lib %{cfg.targetdir}/../lib"
 COPY_PUBLIC_HEADER_FILES = "{COPY} %{cfg.targetdir}/../../../include/AssetSuite/*.h %{cfg.targetdir}/../inc/AssetSuite"
+RUN_PUBLIC_HEADER_HYGIENE_CHECK = "powershell -NoProfile -ExecutionPolicy Bypass -File %{cfg.targetdir}/../../../validation/public_header_hygiene/PublicHeaderHygiene.ps1 -Roots include/AssetSuite,bin/%{cfg.buildcfg}/inc"
 LOCATION_DIRECTORY_NAME = "build"
 
 -- Global Functions
@@ -179,8 +180,9 @@ project "PublicHeaderCompile"
 	language "C++"
 	cppdialect "C++20"
 	targetdir "bin/%{cfg.buildcfg}/validation"
-	files { "validation/public_header_compile/**.cpp" }
+	files { "validation/public_header_compile/**.cpp", "validation/public_header_hygiene/**.ps1" }
 	includedirs { "bin/%{cfg.buildcfg}/inc" }
 	dependson { "AssetSuite" }
+	prebuildcommands { RUN_PUBLIC_HEADER_HYGIENE_CHECK }
 	SetDebugFilters()
 	SetReleaseFilters()

--- a/premake5.lua
+++ b/premake5.lua
@@ -47,7 +47,7 @@ workspace "AssetSuite"
 		project "wavefront"
 		project "bitstream"
 	group "Demo"
-		project "DemoApplication"
+		project "LegacyDemoApplication"
 
 project "AssetSuite"
     kind "SharedLib"
@@ -139,7 +139,7 @@ project "bitstream"
 	SetDebugFilters()
 	SetReleaseFilters()
 	
-project "DemoApplication"
+project "LegacyDemoApplication"
 	kind "ConsoleApp"
 	language "C++"
 	cppdialect "C++17"

--- a/premake5.lua
+++ b/premake5.lua
@@ -7,7 +7,6 @@ CREATE_PUBLIC_INC_DIRECTORY = "{MKDIR} %{cfg.targetdir}/../inc/AssetSuite"
 COPY_RELEASE_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_r.lib %{cfg.targetdir}/../lib"
 COPY_DEBUG_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_d.lib %{cfg.targetdir}/../lib"
 COPY_PUBLIC_HEADER_FILES = "{COPY} %{cfg.targetdir}/../../../include/AssetSuite/*.h %{cfg.targetdir}/../inc/AssetSuite"
-COPY_LEGACY_HEADER_FILES = "{COPY} %{cfg.targetdir}/../../../source/common/*.h %{cfg.targetdir}/../inc"
 LOCATION_DIRECTORY_NAME = "build"
 
 -- Global Functions
@@ -63,8 +62,7 @@ project "AssetSuite"
 		CREATE_LIB_DIRECTORY,
 		CREATE_INC_DIRECTORY,
 		CREATE_PUBLIC_INC_DIRECTORY,
-		COPY_PUBLIC_HEADER_FILES,
-		COPY_LEGACY_HEADER_FILES
+		COPY_PUBLIC_HEADER_FILES
 	}
     files {
 		"include/AssetSuite/**.h",

--- a/premake5.lua
+++ b/premake5.lua
@@ -4,6 +4,7 @@
 CREATE_LIB_DIRECTORY = "{MKDIR} %{cfg.targetdir}/../lib"
 CREATE_INC_DIRECTORY = "{MKDIR} %{cfg.targetdir}/../inc"
 CREATE_PUBLIC_INC_DIRECTORY = "{MKDIR} %{cfg.targetdir}/../inc/AssetSuite"
+CLEAN_INC_DIRECTORY = "powershell -NoProfile -ExecutionPolicy Bypass -Command \"Remove-Item -LiteralPath '%{cfg.targetdir}/../inc' -Recurse -Force -ErrorAction SilentlyContinue\""
 COPY_RELEASE_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_r.lib %{cfg.targetdir}/../lib"
 COPY_DEBUG_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_d.lib %{cfg.targetdir}/../lib"
 COPY_PUBLIC_HEADER_FILES = "{COPY} %{cfg.targetdir}/../../../include/AssetSuite/*.h %{cfg.targetdir}/../inc/AssetSuite"
@@ -61,6 +62,7 @@ project "AssetSuite"
 	-- Copy some files over to have a full DLL release
 	postbuildcommands {
 		CREATE_LIB_DIRECTORY,
+		CLEAN_INC_DIRECTORY,
 		CREATE_INC_DIRECTORY,
 		CREATE_PUBLIC_INC_DIRECTORY,
 		COPY_PUBLIC_HEADER_FILES

--- a/source/demo/README.md
+++ b/source/demo/README.md
@@ -1,0 +1,9 @@
+# Legacy Internal Demo
+
+This demo exercises the pre-2.0 internal implementation API from `source/common`.
+It intentionally uses legacy types and headers such as `AssetSuite::Manager`,
+`BYTE`, `FLOAT`, and STL containers.
+
+Do not use this directory as public SDK integration guidance. External consumers
+should include `<AssetSuite/AssetSuite.h>` from the installed include root and
+follow the 2.0 SDK surface documented in the repository README.

--- a/source/demo/demo.cpp
+++ b/source/demo/demo.cpp
@@ -5,10 +5,14 @@
 
 #define DUMP_BUFFERS 0
 
+// Internal legacy demo for the pre-2.0 implementation API.
+// This intentionally uses source/common headers and must not be treated as the
+// public SDK integration example. External consumers should include
+// <AssetSuite/AssetSuite.h> from the installed SDK header root instead.
 void main()
 {
 	AssetSuite::Manager assetManager;
-	std::cout << "Hello, AssetSuite!" << std::endl;
+	std::cout << "Hello, AssetSuite legacy internal demo!" << std::endl;
 
 	AssetSuite::ImageDescriptor imageDescriptor = {};
 	auto errorCode = assetManager.ImageLoadAndDecode("girl_with_pearl_earring.bmp");

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -2,10 +2,55 @@
 #include <cstdint>
 #include <type_traits>
 
+// Public SDK headers must not expose legacy, platform, or STL-owning API types.
+// Poisoning the tokens before inclusion turns accidental public leakage into a
+// compile failure for this external-consumer validation target.
+#define BYTE ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(BYTE)
+#define FLOAT ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(FLOAT)
+#define UINT ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(UINT)
+#define vector ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(vector)
+#define basic_string ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(basic_string)
+#define string ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(string)
+#define wstring ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(wstring)
+#define u8string ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(u8string)
+#define u16string ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(u16string)
+#define u32string ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(u32string)
+#define filesystem ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(filesystem)
+#define path ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(path)
+#define Manager ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(Manager)
+#define Decoder ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(Decoder)
+#define ImageDecoder ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(ImageDecoder)
+#define MeshDecoder ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(MeshDecoder)
+#define ImageDecoders ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(ImageDecoders)
+#define MeshDecoders ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(MeshDecoders)
+
 #include <AssetSuite/AssetSuite.h>
 #include <AssetSuite/AssetSuiteDescriptors.h>
 #include <AssetSuite/AssetSuiteHandles.h>
 #include <AssetSuite/AssetSuiteTypes.h>
+
+#if defined(_WINDOWS_) || defined(_INC_WINDOWS) || defined(WINAPI)
+#error Public AssetSuite SDK headers must not include Windows.h.
+#endif
+
+#undef BYTE
+#undef FLOAT
+#undef UINT
+#undef vector
+#undef basic_string
+#undef string
+#undef wstring
+#undef u8string
+#undef u16string
+#undef u32string
+#undef filesystem
+#undef path
+#undef Manager
+#undef Decoder
+#undef ImageDecoder
+#undef MeshDecoder
+#undef ImageDecoders
+#undef MeshDecoders
 
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::Result>, int32_t>);
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::PixelFormat>, uint32_t>);

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -2,7 +2,6 @@
 #include <cstdint>
 #include <type_traits>
 
-#include <AssetSuite.h>
 #include <AssetSuite/AssetSuite.h>
 #include <AssetSuite/AssetSuiteDescriptors.h>
 #include <AssetSuite/AssetSuiteHandles.h>

--- a/validation/public_header_hygiene/PublicHeaderHygiene.ps1
+++ b/validation/public_header_hygiene/PublicHeaderHygiene.ps1
@@ -1,0 +1,78 @@
+param(
+	[string[]]$Roots = @(
+		"include/AssetSuite",
+		"bin/Debug/inc",
+		"bin/Release/inc"
+	)
+)
+
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = Resolve-Path (Join-Path $PSScriptRoot "../..")
+$patterns = [ordered]@{
+	"Windows.h include" = '(?i)#\s*include\s*[<"]windows\.h[>"]'
+	"Win32 alias type" = '\b(?:BYTE|FLOAT|UINT)\b'
+	"STL owning API type" = '\bstd\s*::\s*(?:vector|string|basic_string)\b|\bstd\s*::\s*filesystem\s*::\s*path\b'
+	"Legacy manager or decoder surface" = '\b(?:Manager|Decoder|ImageDecoder|MeshDecoder|ImageDecoders|MeshDecoders)\b'
+}
+
+$violations = New-Object System.Collections.Generic.List[string]
+$checkedHeaders = 0
+$expandedRoots = @()
+
+foreach ($root in $Roots) {
+	$expandedRoots += $root -split ","
+}
+
+foreach ($root in $expandedRoots) {
+	if ([string]::IsNullOrWhiteSpace($root)) {
+		continue
+	}
+
+	$root = $root.Trim()
+	$rootPath = $root
+	if (-not [System.IO.Path]::IsPathRooted($rootPath)) {
+		$rootPath = Join-Path $repositoryRoot $rootPath
+	}
+
+	if (-not (Test-Path -LiteralPath $rootPath)) {
+		continue
+	}
+
+	$resolvedRoot = (Resolve-Path -LiteralPath $rootPath).Path
+	$isInstalledIncludeRoot = (Split-Path -Leaf $resolvedRoot) -ieq "inc"
+	$headers = Get-ChildItem -LiteralPath $resolvedRoot -Recurse -File -Filter "*.h"
+
+	foreach ($header in $headers) {
+		$checkedHeaders++
+		$relativePath = $header.FullName.Substring($resolvedRoot.Length).TrimStart("\", "/")
+
+		if ($isInstalledIncludeRoot -and ($relativePath -notmatch '^AssetSuite[\\/][^\\/]+\.h$')) {
+			$violations.Add("${header}: installed header must live under AssetSuite/*.h")
+		}
+
+		$lineNumber = 0
+		foreach ($line in [System.IO.File]::ReadLines($header.FullName)) {
+			$lineNumber++
+			foreach ($pattern in $patterns.GetEnumerator()) {
+				if ($line -match $pattern.Value) {
+					$violations.Add("${header}:${lineNumber}: $($pattern.Key): $line")
+				}
+			}
+		}
+	}
+}
+
+if ($checkedHeaders -eq 0) {
+	Write-Error "No public headers were found to audit."
+}
+
+if ($violations.Count -gt 0) {
+	Write-Host "Public header hygiene violations:"
+	foreach ($violation in $violations) {
+		Write-Host "  $violation"
+	}
+	exit 1
+}
+
+Write-Host "Public header hygiene check passed for $checkedHeaders headers."


### PR DESCRIPTION
## Summary

This PR tightens the AssetSuite 2.0 public SDK boundary so installed headers expose only the intended public include surface.

Changes include:
- stop packaging legacy `source/common` headers into installed include output
- harden `PublicHeaderCompile` with compile-time negative checks for forbidden public symbols
- add a public header hygiene audit for installed headers and `include/AssetSuite`
- rewrite README usage around the 2.0 SDK surface instead of `Manager` and vector-based APIs
- mark the existing demo as a legacy internal sample until 2.0 loading entry points exist

## Why

Issue #38 requires the exported SDK surface to avoid `Windows.h`, Win32 aliases, STL-owning API types, legacy `Manager`, and public decoder interfaces/enums. Internal implementation headers may still use legacy types for now, but they must not be installed or presented as the public SDK boundary.

## Validation

Ran locally:
- Debug `AssetSuite.vcxproj` build
- Release `AssetSuite.vcxproj` build
- Debug `PublicHeaderCompile.vcxproj` validation target
- Release `PublicHeaderCompile.vcxproj` validation target
- public header hygiene scan across 15 exported headers

Notes:
- `premake5` was not available in this shell, so Visual Studio files were not regenerated from Premake during final validation.
- The existing generated public-header validation project already contains the current hygiene hook and passed in both configurations.