### PR TITLE
[codex] Implement context lifecycle API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ handle, including a repeated destroy through the same handle variable, returns
 
 ## Usage
 
-The current 2.0 public SDK headers expose the stable type and version contract used by external consumers:
+The current 2.0 public SDK headers expose the stable type, version, and context
+lifecycle contract used by external consumers:
 
 ```cpp
 #include <AssetSuite/AssetSuite.h>
@@ -67,6 +68,20 @@ int main()
 	AssetSuite::MeshHandle mesh = nullptr;
 
 	AssetSuite::ContextDesc contextDesc = { sizeof(AssetSuite::ContextDesc), 0 };
+	result = AssetSuite::CreateContext(&contextDesc, &context);
+	if (result != AssetSuite::Result::Success)
+	{
+		const char* message = AssetSuite::GetResultString(result);
+		return message != nullptr ? 3 : 4;
+	}
+
+	result = AssetSuite::DestroyContext(&context);
+	if (result != AssetSuite::Result::Success)
+	{
+		const char* message = AssetSuite::GetResultString(result);
+		return message != nullptr ? 5 : 6;
+	}
+
 	AssetSuite::BlobDesc blobDesc = {
 		sizeof(AssetSuite::BlobDesc),
 		0,

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ The public headers are provided under `include/AssetSuite` and are installed und
 
 Public headers do not require `Windows.h`, STL containers, filesystem path types, or internal implementation classes.
 
+## Context Lifecycle Contract
+
+The 2.0 runtime is entered through an opaque `AssetSuite::ContextHandle`.
+Context ownership belongs to the caller after successful creation and must be
+released with `AssetSuite::DestroyContext`.
+
+`AssetSuite::CreateContext(nullptr, &context)` is valid and creates a context
+with default settings. A non-null `AssetSuite::ContextDesc` must use
+`structSize == sizeof(AssetSuite::ContextDesc)` and `flags == 0`. Smaller,
+larger, or otherwise mismatched descriptor sizes are rejected with
+`AssetSuite::Result::ErrorInvalidArgument` for now. Unknown context flag bits are
+also rejected with `AssetSuite::Result::ErrorInvalidArgument`.
+
+`AssetSuite::DestroyContext` takes a pointer to the caller's handle so the SDK
+can set it to `nullptr` after successful destruction. Calling
+`AssetSuite::DestroyContext(nullptr)` or passing a pointer to a null context
+handle returns a defined error instead of causing undefined behavior.
+
 ## Usage
 
 The current 2.0 public SDK headers expose the stable type and version contract used by external consumers:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ with default settings. A non-null `AssetSuite::ContextDesc` must use
 larger, or otherwise mismatched descriptor sizes are rejected with
 `AssetSuite::Result::ErrorInvalidArgument` for now. Unknown context flag bits are
 also rejected with `AssetSuite::Result::ErrorInvalidArgument`.
+The output handle passed to `AssetSuite::CreateContext` must point to a null
+handle; passing a pointer to an already-owned context returns
+`AssetSuite::Result::ErrorInvalidArgument` and leaves that handle unchanged.
 
 `AssetSuite::DestroyContext` takes a pointer to the caller's handle so the SDK
 can set it to `nullptr` after successful destruction. Calling

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ also rejected with `AssetSuite::Result::ErrorInvalidArgument`.
 `AssetSuite::DestroyContext` takes a pointer to the caller's handle so the SDK
 can set it to `nullptr` after successful destruction. Calling
 `AssetSuite::DestroyContext(nullptr)` or passing a pointer to a null context
-handle returns a defined error instead of causing undefined behavior.
+handle, including a repeated destroy through the same handle variable, returns
+`AssetSuite::Result::ErrorInvalidContext` instead of causing undefined behavior.
 
 ## Usage
 

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -3,3 +3,16 @@
 #include "AssetSuiteDescriptors.h"
 #include "AssetSuiteHandles.h"
 #include "AssetSuiteTypes.h"
+
+namespace AssetSuite
+{
+	// Creates a runtime context. Passing nullptr for desc uses default settings.
+	// outContext must not be null and receives ownership of the created handle
+	// on success.
+	ASSET_SUITE_API Result CreateContext(const ContextDesc* desc, ContextHandle* outContext);
+
+	// Destroys a runtime context and sets the caller's handle to nullptr on
+	// success. Passing nullptr or a pointer to a null handle returns a defined
+	// error.
+	ASSET_SUITE_API Result DestroyContext(ContextHandle* context);
+}

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -7,8 +7,8 @@
 namespace AssetSuite
 {
 	// Creates a runtime context. Passing nullptr for desc uses default settings.
-	// outContext must not be null and receives ownership of the created handle
-	// on success.
+	// outContext must point to a null handle and receives ownership of the
+	// created handle on success.
 	ASSET_SUITE_API Result CreateContext(const ContextDesc* desc, ContextHandle* outContext);
 
 	// Destroys a runtime context and sets the caller's handle to nullptr on

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -12,7 +12,7 @@ namespace AssetSuite
 	ASSET_SUITE_API Result CreateContext(const ContextDesc* desc, ContextHandle* outContext);
 
 	// Destroys a runtime context and sets the caller's handle to nullptr on
-	// success. Passing nullptr or a pointer to a null handle returns a defined
-	// error.
+	// success. Passing nullptr or a pointer to a null handle returns
+	// Result::ErrorInvalidContext.
 	ASSET_SUITE_API Result DestroyContext(ContextHandle* context);
 }

--- a/include/AssetSuite/AssetSuiteDescriptors.h
+++ b/include/AssetSuite/AssetSuiteDescriptors.h
@@ -8,7 +8,9 @@ namespace AssetSuite
 {
 	struct ContextDesc
 	{
+		// Must be exactly sizeof(ContextDesc) when a descriptor is supplied.
 		uint32_t structSize;
+		// Reserved for future use. Must be zero.
 		uint32_t flags;
 	};
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -183,8 +183,13 @@ project "PublicHeaderCompile"
 	cppdialect "C++20"
 	targetdir "bin/%{cfg.buildcfg}/validation"
 	files { "validation/public_header_compile/**.cpp", "validation/public_header_hygiene/**.ps1" }
+	links { "AssetSuite" }
 	includedirs { "bin/%{cfg.buildcfg}/inc" }
 	dependson { "AssetSuite" }
 	prebuildcommands { RUN_PUBLIC_HEADER_HYGIENE_CHECK }
 	SetDebugFilters()
 	SetReleaseFilters()
+	filter "configurations:Debug"
+		postbuildcommands { "{COPY} %{cfg.targetdir}/../bin/assetsuite_d.dll %{cfg.targetdir}" }
+	filter "configurations:Release"
+		postbuildcommands { "{COPY} %{cfg.targetdir}/../bin/assetsuite_r.dll %{cfg.targetdir}" }

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -1,6 +1,7 @@
 #pragma warning (disable : 4251)
 
 #include "AssetSuite.h"
+#include "AssetSuiteContext.h"
 
 #include "../wavefront/ModelLoader.h"
 #include "../bmp/BmpDecoder.h"
@@ -8,9 +9,34 @@
 #include "../ppm/PpmEncoder.h"
 #include "../bypass/BypassEncoder.h"
 
+#include <new>
+
 namespace
 {
 	constexpr AssetSuite::Version ASSET_SUITE_VERSION = { 2, 0, 0, 0 };
+	constexpr AssetSuite::ContextDesc DEFAULT_CONTEXT_DESC = { sizeof(AssetSuite::ContextDesc), 0 };
+
+	AssetSuite::Result NormalizeContextDesc(const AssetSuite::ContextDesc* desc, AssetSuite::ContextDesc& normalizedDesc)
+	{
+		if (!desc)
+		{
+			normalizedDesc = DEFAULT_CONTEXT_DESC;
+			return AssetSuite::Result::Success;
+		}
+
+		if (desc->structSize != sizeof(AssetSuite::ContextDesc))
+		{
+			return AssetSuite::Result::ErrorInvalidArgument;
+		}
+
+		if (desc->flags != 0)
+		{
+			return AssetSuite::Result::ErrorInvalidArgument;
+		}
+
+		normalizedDesc = *desc;
+		return AssetSuite::Result::Success;
+	}
 }
 
 AssetSuite::Result AssetSuite::GetVersion(Version* outVersion)
@@ -51,6 +77,46 @@ const char* AssetSuite::GetResultString(Result result)
 	default:
 		return "Unknown result";
 	}
+}
+
+AssetSuite::Result AssetSuite::CreateContext(const ContextDesc* desc, ContextHandle* outContext)
+{
+	if (!outContext)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	*outContext = nullptr;
+
+	ContextDesc normalizedDesc = DEFAULT_CONTEXT_DESC;
+	const Result validationResult = NormalizeContextDesc(desc, normalizedDesc);
+	if (validationResult != Result::Success)
+	{
+		return validationResult;
+	}
+
+	try
+	{
+		*outContext = new AssetSuiteContext_t(normalizedDesc);
+	}
+	catch (const std::bad_alloc&)
+	{
+		return Result::ErrorOutOfMemory;
+	}
+
+	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::DestroyContext(ContextHandle* context)
+{
+	if (!context || !*context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	delete *context;
+	*context = nullptr;
+	return Result::Success;
 }
 
 AssetSuite::Manager::Manager() : modelLoader(nullptr), imageInfo(), meshInfo()

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -86,7 +86,10 @@ AssetSuite::Result AssetSuite::CreateContext(const ContextDesc* desc, ContextHan
 		return Result::ErrorInvalidArgument;
 	}
 
-	*outContext = nullptr;
+	if (*outContext)
+	{
+		return Result::ErrorInvalidArgument;
+	}
 
 	ContextDesc normalizedDesc = DEFAULT_CONTEXT_DESC;
 	const Result validationResult = NormalizeContextDesc(desc, normalizedDesc);
@@ -102,6 +105,10 @@ AssetSuite::Result AssetSuite::CreateContext(const ContextDesc* desc, ContextHan
 	catch (const std::bad_alloc&)
 	{
 		return Result::ErrorOutOfMemory;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
 	}
 
 	return Result::Success;

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -1,0 +1,6 @@
+#include "AssetSuiteContext.h"
+
+AssetSuite::AssetSuiteContext_t::AssetSuiteContext_t(const ContextDesc& desc)
+	: desc(desc)
+{
+}

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -1,6 +1,1 @@
 #include "AssetSuiteContext.h"
-
-AssetSuite::AssetSuiteContext_t::AssetSuiteContext_t(const ContextDesc& desc)
-	: desc(desc)
-{
-}

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "AssetSuite.h"
+
+namespace AssetSuite
+{
+	struct AssetSuiteContext_t
+	{
+		explicit AssetSuiteContext_t(const ContextDesc& desc);
+
+		ContextDesc desc;
+		Manager manager;
+	};
+}

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -6,7 +6,10 @@ namespace AssetSuite
 {
 	struct AssetSuiteContext_t
 	{
-		explicit AssetSuiteContext_t(const ContextDesc& desc);
+		explicit AssetSuiteContext_t(const ContextDesc& desc)
+			: desc(desc)
+		{
+		}
 
 		ContextDesc desc;
 		Manager manager;

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -50,6 +50,100 @@ namespace GeneralUnitTests
 			Assert::AreEqual("Unknown result", AssetSuite::GetResultString(unknownResult));
 		}
 
+		TEST_METHOD(CreateContextAcceptsNullDescriptor)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+
+			const auto result = AssetSuite::CreateContext(nullptr, &context);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNotNull(context);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(CreateContextAcceptsDefaultDescriptor)
+		{
+			AssetSuite::ContextDesc desc = { sizeof(AssetSuite::ContextDesc), 0 };
+			AssetSuite::ContextHandle context = nullptr;
+
+			const auto result = AssetSuite::CreateContext(&desc, &context);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNotNull(context);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(CreateContextRejectsNullOutput)
+		{
+			const auto result = AssetSuite::CreateContext(nullptr, nullptr);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == result);
+		}
+
+		TEST_METHOD(CreateContextRejectsInvalidDescriptorSize)
+		{
+			AssetSuite::ContextDesc desc = { sizeof(AssetSuite::ContextDesc) - 1, 0 };
+			AssetSuite::ContextHandle context = reinterpret_cast<AssetSuite::ContextHandle>(1);
+
+			const auto result = AssetSuite::CreateContext(&desc, &context);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == result);
+			Assert::IsNull(context);
+		}
+
+		TEST_METHOD(CreateContextRejectsReservedFlags)
+		{
+			AssetSuite::ContextDesc desc = { sizeof(AssetSuite::ContextDesc), 1 };
+			AssetSuite::ContextHandle context = reinterpret_cast<AssetSuite::ContextHandle>(1);
+
+			const auto result = AssetSuite::CreateContext(&desc, &context);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == result);
+			Assert::IsNull(context);
+		}
+
+		TEST_METHOD(DestroyContextReleasesValidContextAndClearsHandle)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::IsNotNull(context);
+
+			const auto result = AssetSuite::DestroyContext(&context);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNull(context);
+		}
+
+		TEST_METHOD(DestroyContextRejectsNullHandlePointer)
+		{
+			const auto result = AssetSuite::DestroyContext(nullptr);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == result);
+		}
+
+		TEST_METHOD(DestroyContextRejectsNullHandle)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+
+			const auto result = AssetSuite::DestroyContext(&context);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == result);
+		}
+
+		TEST_METHOD(DestroyContextReturnsInvalidContextAfterRepeatedDestroy)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::DestroyContext(&context));
+
+			const auto result = AssetSuite::DestroyContext(&context);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == result);
+			Assert::IsNull(context);
+		}
+
 	private:
 		static void AssertResultString(AssetSuite::Result result, const char* expected)
 		{
@@ -57,6 +151,12 @@ namespace GeneralUnitTests
 
 			Assert::IsNotNull(actual);
 			Assert::AreEqual(expected, actual);
+		}
+
+		static void DestroyContextForCleanup(AssetSuite::ContextHandle& context)
+		{
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::DestroyContext(&context));
+			Assert::IsNull(context);
 		}
 	};
 

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -85,7 +85,7 @@ namespace GeneralUnitTests
 		TEST_METHOD(CreateContextRejectsInvalidDescriptorSize)
 		{
 			AssetSuite::ContextDesc desc = { sizeof(AssetSuite::ContextDesc) - 1, 0 };
-			AssetSuite::ContextHandle context = reinterpret_cast<AssetSuite::ContextHandle>(1);
+			AssetSuite::ContextHandle context = nullptr;
 
 			const auto result = AssetSuite::CreateContext(&desc, &context);
 
@@ -96,12 +96,26 @@ namespace GeneralUnitTests
 		TEST_METHOD(CreateContextRejectsReservedFlags)
 		{
 			AssetSuite::ContextDesc desc = { sizeof(AssetSuite::ContextDesc), 1 };
-			AssetSuite::ContextHandle context = reinterpret_cast<AssetSuite::ContextHandle>(1);
+			AssetSuite::ContextHandle context = nullptr;
 
 			const auto result = AssetSuite::CreateContext(&desc, &context);
 
 			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == result);
 			Assert::IsNull(context);
+		}
+
+		TEST_METHOD(CreateContextRejectsNonNullOutputAndPreservesHandle)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			AssetSuite::ContextHandle originalContext = context;
+
+			const auto result = AssetSuite::CreateContext(nullptr, &context);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == result);
+			Assert::IsTrue(originalContext == context);
+
+			DestroyContextForCleanup(context);
 		}
 
 		TEST_METHOD(DestroyContextReleasesValidContextAndClearsHandle)

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -77,6 +77,13 @@ static_assert(offsetof(AssetSuite::BlobDesc, structSize) == 0);
 static_assert(offsetof(AssetSuite::ImageDesc, structSize) == 0);
 static_assert(offsetof(AssetSuite::MeshDesc, structSize) == 0);
 
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::CreateContext),
+	AssetSuite::Result (*)(const AssetSuite::ContextDesc*, AssetSuite::ContextHandle*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::DestroyContext),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle*)>);
+
 int main()
 {
 	AssetSuite::ContextHandle context = nullptr;
@@ -89,9 +96,18 @@ int main()
 	AssetSuite::ImageDesc imageDesc = { sizeof(AssetSuite::ImageDesc), 0, 0, AssetSuite::PixelFormat::Unknown, 0, 0 };
 	AssetSuite::MeshDesc meshDesc = { sizeof(AssetSuite::MeshDesc), 0, 0, 0, 0 };
 
+	const AssetSuite::Result createDefaultResult = AssetSuite::CreateContext(nullptr, &context);
+	const AssetSuite::Result destroyDefaultResult = AssetSuite::DestroyContext(&context);
+	const AssetSuite::Result createExplicitResult = AssetSuite::CreateContext(&contextDesc, &context);
+	const AssetSuite::Result destroyExplicitResult = AssetSuite::DestroyContext(&context);
+
 	return context || blob || image || mesh ||
 		contextDesc.structSize == 0 ||
 		blobDesc.structSize == 0 ||
 		imageDesc.structSize == 0 ||
-		meshDesc.structSize == 0;
+		meshDesc.structSize == 0 ||
+		createDefaultResult == AssetSuite::Result::ErrorUnknown ||
+		destroyDefaultResult == AssetSuite::Result::ErrorUnknown ||
+		createExplicitResult == AssetSuite::Result::ErrorUnknown ||
+		destroyExplicitResult == AssetSuite::Result::ErrorUnknown;
 }


### PR DESCRIPTION
## Summary

Implements the first handle-based context lifecycle surface for AssetSuite 2.0.

- Documents the context lifecycle contract, including default creation, descriptor validation, ownership, and repeated-destroy behavior.
- Adds public `CreateContext` and `DestroyContext` declarations with pointer-based destroy semantics.
- Introduces the private `AssetSuiteContext_t` runtime backing type and wires create/destroy validation paths.
- Adds lifecycle unit tests and extends public-header validation to compile external consumer lifecycle usage.
- Links the public-header validation app against AssetSuite so imported lifecycle functions resolve in CI.

## Validation

- Compiled `source\common\AssetSuite.cpp` directly with `cl`.
- Compiled `unit_tests\GeneralUnitTests.cpp` directly with `cl`.
- Compiled `validation\public_header_compile\PublicHeaderCompile.cpp` directly with `cl /std:c++20 /EHsc /Iinclude`.
- Local full MSBuild invocation is blocked by this machine's duplicated `Path`/`PATH` environment entries, but CI should exercise the generated projects on a clean runner.

Fixes #36