### PR TITLE
[codex] Implement logging callback contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The public headers are provided under `include/AssetSuite` and are installed und
 
 - `AssetSuite::Result` and `AssetSuite::Version`
 - `AssetSuite::GetVersion` and `AssetSuite::GetResultString`
+- `AssetSuite::LogLevel`, `AssetSuite::LoggingCallback`, and `AssetSuite::SetLoggingCallback`
 - opaque handle types such as `AssetSuite::ContextHandle`, `AssetSuite::BlobHandle`, `AssetSuite::ImageHandle`, and `AssetSuite::MeshHandle`
 - plain descriptor structs such as `AssetSuite::ContextDesc`, `AssetSuite::BlobDesc`, `AssetSuite::ImageDesc`, and `AssetSuite::MeshDesc`
 - SDK enums such as `AssetSuite::AssetFormat`, `AssetSuite::PixelFormat`, and `AssetSuite::MeshAttributeFlags`
@@ -74,6 +75,20 @@ lifecycle contract used by external consumers:
 
 #include <cstdint>
 
+struct AppLogger
+{
+	int messagesSeen;
+};
+
+void OnAssetSuiteLog(AssetSuite::LogLevel level, const char* message, void* userData)
+{
+	AppLogger* logger = static_cast<AppLogger*>(userData);
+	++logger->messagesSeen;
+
+	(void)level;
+	(void)message;
+}
+
 int main()
 {
 	AssetSuite::Version version = {};
@@ -98,11 +113,34 @@ int main()
 		return message != nullptr ? 3 : 4;
 	}
 
-	result = AssetSuite::DestroyContext(&context);
+	AppLogger logger = {};
+	result = AssetSuite::SetLoggingCallback(
+		context,
+		&OnAssetSuiteLog,
+		AssetSuite::LogLevel::Warning,
+		&logger);
 	if (result != AssetSuite::Result::Success)
 	{
 		const char* message = AssetSuite::GetResultString(result);
 		return message != nullptr ? 5 : 6;
+	}
+
+	result = AssetSuite::SetLoggingCallback(
+		context,
+		nullptr,
+		AssetSuite::LogLevel::Trace,
+		nullptr);
+	if (result != AssetSuite::Result::Success)
+	{
+		const char* message = AssetSuite::GetResultString(result);
+		return message != nullptr ? 7 : 8;
+	}
+
+	result = AssetSuite::DestroyContext(&context);
+	if (result != AssetSuite::Result::Success)
+	{
+		const char* message = AssetSuite::GetResultString(result);
+		return message != nullptr ? 9 : 10;
 	}
 
 	AssetSuite::BlobDesc blobDesc = {

--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ can set it to `nullptr` after successful destruction. Calling
 handle, including a repeated destroy through the same handle variable, returns
 `AssetSuite::Result::ErrorInvalidContext` instead of causing undefined behavior.
 
+## Logging Callback Contract
+
+Logging is configured per `AssetSuite::ContextHandle` with
+`AssetSuite::SetLoggingCallback`. A successful call replaces the context's
+previous callback pointer, minimum enabled `AssetSuite::LogLevel`, and opaque
+`userData` pointer together. Passing `nullptr` for the callback unregisters
+logging for that context and discards the previous callback state.
+
+`AssetSuite::LogLevel` values are ordered from least to most severe:
+`Trace`, `Debug`, `Info`, `Warning`, `Error`, and `Fatal`. The configured
+minimum level is inclusive: events below it are suppressed, while events equal
+to or above it are delivered when a callback is registered.
+
+The callback receives a null-terminated UTF-8 message pointer and the exact
+`userData` pointer supplied during registration. The SDK does not take ownership
+of `userData`, does not interpret it, and does not manage its lifetime. The
+message pointer is valid only for the duration of the callback invocation.
+Callback invocation follows the same external synchronization expectations as
+other operations on the context.
+
 ## Usage
 
 The current 2.0 public SDK headers expose the stable type, version, and context

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -30,7 +30,8 @@ namespace AssetSuite
 	// null-terminated UTF-8 and remains valid only for the duration of the
 	// callback invocation. userData is stored without interpretation and passed
 	// back unchanged. Callback invocation follows the context's external
-	// synchronization requirements.
+	// synchronization requirements. Passing a null or otherwise invalid context
+	// returns Result::ErrorInvalidContext.
 	ASSET_SUITE_API Result SetLoggingCallback(
 		ContextHandle context,
 		LoggingCallback callback,

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -16,13 +16,21 @@ namespace AssetSuite
 	// Result::ErrorInvalidContext.
 	ASSET_SUITE_API Result DestroyContext(ContextHandle* context);
 
-	// Registers or replaces the logging callback for a runtime context.
-	// Passing nullptr for callback unregisters logging for the context.
-	// Events with a level below minLevel are suppressed. The message pointer
-	// passed to the callback is null-terminated UTF-8 and remains valid only
-	// for the duration of the callback invocation. userData is stored without
-	// interpretation and passed back unchanged. Callback invocation follows the
-	// context's external synchronization requirements.
+	// Registers, replaces, or unregisters the logging callback for a runtime
+	// context. A successful registration replaces the previous callback,
+	// minimum level, and userData together. Passing nullptr for callback
+	// unregisters logging and discards the previous callback state.
+	//
+	// LogLevel values are ordered from least to most severe. Events with a
+	// level numerically lower than minLevel are suppressed, and events with a
+	// level equal to or greater than minLevel are delivered when a callback is
+	// registered.
+	//
+	// The callback does not take ownership of message. The message pointer is
+	// null-terminated UTF-8 and remains valid only for the duration of the
+	// callback invocation. userData is stored without interpretation and passed
+	// back unchanged. Callback invocation follows the context's external
+	// synchronization requirements.
 	ASSET_SUITE_API Result SetLoggingCallback(
 		ContextHandle context,
 		LoggingCallback callback,

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -30,8 +30,8 @@ namespace AssetSuite
 	// null-terminated UTF-8 and remains valid only for the duration of the
 	// callback invocation. userData is stored without interpretation and passed
 	// back unchanged. Callback invocation follows the context's external
-	// synchronization requirements. Passing a null or otherwise invalid context
-	// returns Result::ErrorInvalidContext.
+	// synchronization requirements. Passing a null context returns
+	// Result::ErrorInvalidContext.
 	ASSET_SUITE_API Result SetLoggingCallback(
 		ContextHandle context,
 		LoggingCallback callback,

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -15,4 +15,17 @@ namespace AssetSuite
 	// success. Passing nullptr or a pointer to a null handle returns
 	// Result::ErrorInvalidContext.
 	ASSET_SUITE_API Result DestroyContext(ContextHandle* context);
+
+	// Registers or replaces the logging callback for a runtime context.
+	// Passing nullptr for callback unregisters logging for the context.
+	// Events with a level below minLevel are suppressed. The message pointer
+	// passed to the callback is null-terminated UTF-8 and remains valid only
+	// for the duration of the callback invocation. userData is stored without
+	// interpretation and passed back unchanged. Callback invocation follows the
+	// context's external synchronization requirements.
+	ASSET_SUITE_API Result SetLoggingCallback(
+		ContextHandle context,
+		LoggingCallback callback,
+		LogLevel minLevel,
+		void* userData);
 }

--- a/include/AssetSuite/AssetSuiteTypes.h
+++ b/include/AssetSuite/AssetSuiteTypes.h
@@ -55,6 +55,18 @@ namespace AssetSuite
 		Index = 1u << 4
 	};
 
+	enum class LogLevel : uint32_t
+	{
+		Trace = 0,
+		Debug = 1,
+		Info = 2,
+		Warning = 3,
+		Error = 4,
+		Fatal = 5
+	};
+
+	typedef void (*LoggingCallback)(LogLevel level, const char* message, void* userData);
+
 	ASSET_SUITE_API Result GetVersion(Version* outVersion);
 	ASSET_SUITE_API const char* GetResultString(Result result);
 }

--- a/include/AssetSuite/AssetSuiteTypes.h
+++ b/include/AssetSuite/AssetSuiteTypes.h
@@ -55,6 +55,8 @@ namespace AssetSuite
 		Index = 1u << 4
 	};
 
+	// Logging severity values are ordered from least to most severe. A minimum
+	// enabled level suppresses events with numerically lower values.
 	enum class LogLevel : uint32_t
 	{
 		Trace = 0,
@@ -65,6 +67,9 @@ namespace AssetSuite
 		Fatal = 5
 	};
 
+	// The message pointer is null-terminated UTF-8 and is valid only for the
+	// duration of the callback invocation. userData is the opaque pointer
+	// supplied to SetLoggingCallback.
 	typedef void (*LoggingCallback)(LogLevel level, const char* message, void* userData);
 
 	ASSET_SUITE_API Result GetVersion(Version* outVersion);

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -126,6 +126,23 @@ AssetSuite::Result AssetSuite::DestroyContext(ContextHandle* context)
 	return Result::Success;
 }
 
+AssetSuite::Result AssetSuite::SetLoggingCallback(
+	ContextHandle context,
+	LoggingCallback callback,
+	LogLevel minLevel,
+	void* userData)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	context->loggingCallback = callback;
+	context->minimumLogLevel = minLevel;
+	context->loggingUserData = userData;
+	return Result::Success;
+}
+
 AssetSuite::Manager::Manager() : modelLoader(nullptr), imageInfo(), meshInfo()
 {
 	modelLoader = new ModelLoader;

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -1,16 +1,1 @@
 #include "AssetSuiteContext.h"
-
-void AssetSuite::DispatchLogEvent(ContextHandle context, LogLevel level, const char* message)
-{
-	if (!context || !context->loggingCallback || !message)
-	{
-		return;
-	}
-
-	if (static_cast<uint32_t>(level) < static_cast<uint32_t>(context->minimumLogLevel))
-	{
-		return;
-	}
-
-	context->loggingCallback(level, message, context->loggingUserData);
-}

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -1,1 +1,16 @@
 #include "AssetSuiteContext.h"
+
+void AssetSuite::DispatchLogEvent(ContextHandle context, LogLevel level, const char* message)
+{
+	if (!context || !context->loggingCallback || !message)
+	{
+		return;
+	}
+
+	if (static_cast<uint32_t>(level) < static_cast<uint32_t>(context->minimumLogLevel))
+	{
+		return;
+	}
+
+	context->loggingCallback(level, message, context->loggingUserData);
+}

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -21,4 +21,6 @@ namespace AssetSuite
 		LogLevel minimumLogLevel;
 		void* loggingUserData;
 	};
+
+	void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message);
 }

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -22,5 +22,18 @@ namespace AssetSuite
 		void* loggingUserData;
 	};
 
-	ASSET_SUITE_API void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message);
+	inline void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message)
+	{
+		if (!context || !context->loggingCallback || !message)
+		{
+			return;
+		}
+
+		if (static_cast<uint32_t>(level) < static_cast<uint32_t>(context->minimumLogLevel))
+		{
+			return;
+		}
+
+		context->loggingCallback(level, message, context->loggingUserData);
+	}
 }

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -8,10 +8,17 @@ namespace AssetSuite
 	{
 		explicit AssetSuiteContext_t(const ContextDesc& desc)
 			: desc(desc)
+			, manager()
+			, loggingCallback(nullptr)
+			, minimumLogLevel(LogLevel::Info)
+			, loggingUserData(nullptr)
 		{
 		}
 
 		ContextDesc desc;
 		Manager manager;
+		LoggingCallback loggingCallback;
+		LogLevel minimumLogLevel;
+		void* loggingUserData;
 	};
 }

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -22,5 +22,5 @@ namespace AssetSuite
 		void* loggingUserData;
 	};
 
-	void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message);
+	ASSET_SUITE_API void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message);
 }

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -1,6 +1,7 @@
 #pragma warning (disable : 4251)
 #include <CppUnitTest.h>
 #include "../source/common/AssetSuite.h"
+#include "../source/common/AssetSuiteContext.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -158,7 +159,131 @@ namespace GeneralUnitTests
 			Assert::IsNull(context);
 		}
 
+		TEST_METHOD(SetLoggingCallbackRejectsNullContext)
+		{
+			LogCapture capture = {};
+
+			const auto result = AssetSuite::SetLoggingCallback(
+				nullptr,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Info,
+				&capture);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == result);
+		}
+
+		TEST_METHOD(SetLoggingCallbackRegistersCallbackAndPassesUserData)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			LogCapture capture = {};
+
+			const auto result = AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Info,
+				&capture);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+
+			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Warning, "registered");
+
+			Assert::AreEqual(1, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Warning == capture.lastLevel);
+			Assert::AreEqual("registered", capture.lastMessage);
+			Assert::IsTrue(&capture == capture.lastUserData);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(SetLoggingCallbackAppliesMinimumLogLevelFiltering)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			LogCapture capture = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Warning,
+				&capture));
+
+			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Info, "filtered");
+			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Warning, "warning");
+			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Error, "error");
+
+			Assert::AreEqual(2, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
+			Assert::AreEqual("error", capture.lastMessage);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(SetLoggingCallbackReplacesCallbackState)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			LogCapture firstCapture = {};
+			LogCapture secondCapture = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Info,
+				&firstCapture));
+
+			const auto result = AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Error,
+				&secondCapture);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+
+			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Warning, "filtered");
+			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Error, "replacement");
+
+			Assert::AreEqual(0, firstCapture.callCount);
+			Assert::AreEqual(1, secondCapture.callCount);
+			Assert::AreEqual("replacement", secondCapture.lastMessage);
+			Assert::IsTrue(&secondCapture == secondCapture.lastUserData);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(SetLoggingCallbackUnregistersNullCallback)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			LogCapture capture = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Trace,
+				&capture));
+
+			const auto result = AssetSuite::SetLoggingCallback(
+				context,
+				nullptr,
+				AssetSuite::LogLevel::Trace,
+				nullptr);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+
+			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Fatal, "unregistered");
+
+			Assert::AreEqual(0, capture.callCount);
+
+			DestroyContextForCleanup(context);
+		}
+
 	private:
+		struct LogCapture
+		{
+			int callCount;
+			AssetSuite::LogLevel lastLevel;
+			const char* lastMessage;
+			void* lastUserData;
+		};
+
 		static void AssertResultString(AssetSuite::Result result, const char* expected)
 		{
 			const char* actual = AssetSuite::GetResultString(result);
@@ -171,6 +296,15 @@ namespace GeneralUnitTests
 		{
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::DestroyContext(&context));
 			Assert::IsNull(context);
+		}
+
+		static void CaptureLogEvent(AssetSuite::LogLevel level, const char* message, void* userData)
+		{
+			auto* capture = static_cast<LogCapture*>(userData);
+			++capture->callCount;
+			capture->lastLevel = level;
+			capture->lastMessage = message;
+			capture->lastUserData = userData;
 		}
 	};
 

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -102,6 +102,10 @@ static_assert(std::is_same_v<
 		AssetSuite::LogLevel,
 		void*)>);
 
+void PublicLoggingCallback(AssetSuite::LogLevel, const char*, void*)
+{
+}
+
 int main()
 {
 	AssetSuite::ContextHandle context = nullptr;
@@ -117,6 +121,16 @@ int main()
 	const AssetSuite::Result createDefaultResult = AssetSuite::CreateContext(nullptr, &context);
 	const AssetSuite::Result destroyDefaultResult = AssetSuite::DestroyContext(&context);
 	const AssetSuite::Result createExplicitResult = AssetSuite::CreateContext(&contextDesc, &context);
+	const AssetSuite::Result setLoggingResult = AssetSuite::SetLoggingCallback(
+		context,
+		&PublicLoggingCallback,
+		AssetSuite::LogLevel::Warning,
+		&contextDesc);
+	const AssetSuite::Result unregisterLoggingResult = AssetSuite::SetLoggingCallback(
+		context,
+		nullptr,
+		AssetSuite::LogLevel::Trace,
+		nullptr);
 	const AssetSuite::Result destroyExplicitResult = AssetSuite::DestroyContext(&context);
 
 	return context || blob || image || mesh ||
@@ -127,5 +141,7 @@ int main()
 		createDefaultResult == AssetSuite::Result::ErrorUnknown ||
 		destroyDefaultResult == AssetSuite::Result::ErrorUnknown ||
 		createExplicitResult == AssetSuite::Result::ErrorUnknown ||
+		setLoggingResult == AssetSuite::Result::ErrorUnknown ||
+		unregisterLoggingResult == AssetSuite::Result::ErrorUnknown ||
 		destroyExplicitResult == AssetSuite::Result::ErrorUnknown;
 }

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -57,6 +57,12 @@ static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::PixelFormat>, ui
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::AssetFormat>, uint32_t>);
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::MeshAttributeFlags>, uint32_t>);
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::LogLevel>, uint32_t>);
+static_assert(static_cast<uint32_t>(AssetSuite::LogLevel::Trace) == 0);
+static_assert(static_cast<uint32_t>(AssetSuite::LogLevel::Debug) == 1);
+static_assert(static_cast<uint32_t>(AssetSuite::LogLevel::Info) == 2);
+static_assert(static_cast<uint32_t>(AssetSuite::LogLevel::Warning) == 3);
+static_assert(static_cast<uint32_t>(AssetSuite::LogLevel::Error) == 4);
+static_assert(static_cast<uint32_t>(AssetSuite::LogLevel::Fatal) == 5);
 
 static_assert(std::is_same_v<
 	AssetSuite::LoggingCallback,

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -56,6 +56,11 @@ static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::Result>, int32_t
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::PixelFormat>, uint32_t>);
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::AssetFormat>, uint32_t>);
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::MeshAttributeFlags>, uint32_t>);
+static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::LogLevel>, uint32_t>);
+
+static_assert(std::is_same_v<
+	AssetSuite::LoggingCallback,
+	void (*)(AssetSuite::LogLevel, const char*, void*)>);
 
 static_assert(std::is_pointer_v<AssetSuite::ContextHandle>);
 static_assert(std::is_pointer_v<AssetSuite::BlobHandle>);
@@ -83,6 +88,13 @@ static_assert(std::is_same_v<
 static_assert(std::is_same_v<
 	decltype(&AssetSuite::DestroyContext),
 	AssetSuite::Result (*)(AssetSuite::ContextHandle*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::SetLoggingCallback),
+	AssetSuite::Result (*)(
+		AssetSuite::ContextHandle,
+		AssetSuite::LoggingCallback,
+		AssetSuite::LogLevel,
+		void*)>);
 
 int main()
 {


### PR DESCRIPTION
## Summary

Implements the AssetSuite 2.0 logging callback contract for issue #37.

Changes include:
- public `LogLevel`, `LoggingCallback`, and `SetLoggingCallback` API surface
- explicit callback behavior contract for unregister, replacement, filtering, message lifetime, user data, and synchronization
- per-context callback state stored behind `ContextHandle`
- registration implementation and internal dispatch helper
- unit coverage for registration, replacement, filtering, user-data passthrough, unregister, and invalid-context handling
- public-header compile validation and README usage documentation

## Validation

Targeted compile checks run locally:
- `cl /std:c++20 /EHsc /I include /c validation\public_header_compile\PublicHeaderCompile.cpp`
- `cl /std:c++17 /EHsc /DASSETSUITE_EXPORTS /I include /I <VS UnitTest include> /c unit_tests\GeneralUnitTests.cpp`
- `cl /std:c++20 /EHsc /DASSETSUITE_EXPORTS /I include /c source\common\AssetSuite.cpp`
- `cl /std:c++20 /EHsc /DASSETSUITE_EXPORTS /I include /c source\common\AssetSuiteContext.cpp`
- `git diff --check`

Full solution builds run locally with a cleaned child-process environment to avoid the shell's duplicate `PATH`/`Path` entries:
- `msbuild build\AssetSuite.sln /t:Build /p:Configuration=Debug /p:Platform=x64 /m:1 /v:minimal`
- `msbuild build\AssetSuite.sln /t:Build /p:Configuration=Release /p:Platform=x64 /m:1 /v:minimal`