### PR TITLE
[codex] Create private runtime context implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Asset loading entry points will build on these handle and descriptor types as th
 
 Build the project with Premake-generated Visual Studio projects. The package output contains Debug and Release binaries plus the public SDK headers under `bin/<Config>/inc/AssetSuite`.
 
-The installed public header surface is validated by `PublicHeaderCompile`, which compiles an external-consumer translation unit and checks that installed headers do not expose platform-specific, legacy, or STL-owning API types.
+The installed public header surface is validated by `PublicHeaderCompile`, which compiles an external-consumer translation unit and checks that installed headers do not expose platform-specific, legacy, STL-owning, or private runtime implementation types. The validation flow also verifies that installed headers remain under `AssetSuite/*.h`.
 
 ## Installation
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -9,6 +9,7 @@ COPY_RELEASE_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_r.lib %{cfg.targetdi
 COPY_DEBUG_LIB_FILE = "{COPY} %{cfg.targetdir}/assetsuite_d.lib %{cfg.targetdir}/../lib"
 COPY_PUBLIC_HEADER_FILES = "{COPY} %{cfg.targetdir}/../../../include/AssetSuite/*.h %{cfg.targetdir}/../inc/AssetSuite"
 RUN_PUBLIC_HEADER_HYGIENE_CHECK = "powershell -NoProfile -ExecutionPolicy Bypass -File %{cfg.targetdir}/../../../validation/public_header_hygiene/PublicHeaderHygiene.ps1 -Roots include/AssetSuite,bin/%{cfg.buildcfg}/inc"
+RUN_PUBLIC_INSTALL_SURFACE_CHECK = "powershell -NoProfile -ExecutionPolicy Bypass -File %{cfg.targetdir}/../../../validation/public_header_hygiene/AssertPublicInstallSurface.ps1 -InstalledIncludeRoot bin/%{cfg.buildcfg}/inc"
 LOCATION_DIRECTORY_NAME = "build"
 
 -- Global Functions
@@ -187,7 +188,10 @@ project "PublicHeaderCompile"
 	links { "AssetSuite" }
 	includedirs { "bin/%{cfg.buildcfg}/inc" }
 	dependson { "AssetSuite" }
-	prebuildcommands { RUN_PUBLIC_HEADER_HYGIENE_CHECK }
+	prebuildcommands {
+		RUN_PUBLIC_INSTALL_SURFACE_CHECK,
+		RUN_PUBLIC_HEADER_HYGIENE_CHECK
+	}
 	SetDebugFilters()
 	SetReleaseFilters()
 	filter "configurations:Debug"

--- a/premake5.lua
+++ b/premake5.lua
@@ -69,7 +69,8 @@ project "AssetSuite"
 	}
     files {
 		"include/AssetSuite/**.h",
-		"source/common/**.h", "source/common/**.cpp"
+		"source/common/**.h", "source/common/**.cpp",
+		"source/runtime/**.h", "source/runtime/**.cpp"
 	}
 	SetDebugFilters()
 	SetReleaseFilters()

--- a/premake5.lua
+++ b/premake5.lua
@@ -167,8 +167,13 @@ project "UnitTest"
 	language "C++"
 	cppdialect "C++17"
 	targetdir "bin/%{cfg.buildcfg}/tests"
-	files { "unit_tests/**.h", "unit_tests/**.cpp" }
-	links { "AssetSuite", "zlib", "bmp", "png", "ppm", "wavefront", "bitstream" }
+	defines { "ASSETSUITE_UNIT_TEST_PRIVATE_RUNTIME" }
+	files {
+		"unit_tests/**.h", "unit_tests/**.cpp",
+		"source/common/AssetSuiteContext.cpp",
+		"source/runtime/**.cpp"
+	}
+	links { "AssetSuite", "zlib", "bmp", "png", "ppm", "bypass", "wavefront", "bitstream" }
 	includedirs { "include" }
 	SetDebugFilters()
 	SetReleaseFilters()

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -295,8 +295,9 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
 {
       auto& state = State();
       // Fetch the group data
-      auto groupOffset = state.modelLoader->GetGroupOffset(meshName);
-      auto groupSize = state.modelLoader->GetGroupSize(meshName);
+      auto& modelLoader = *state.codecs.modelLoader;
+      auto groupOffset = modelLoader.GetGroupOffset(meshName);
+      auto groupSize = modelLoader.GetGroupSize(meshName);
       state.meshInfo.numOfVertices = groupSize;
       state.meshInfo.numOfIndices = groupSize;
       descriptor.numOfVertices = state.meshInfo.numOfVertices;
@@ -308,10 +309,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 4);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = state.modelLoader->GetFace(i + groupOffset);
+                  auto face = modelLoader.GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto vertex = state.modelLoader->GetVertex(face.vertexIndex[j]);
+                        auto vertex = modelLoader.GetVertex(face.vertexIndex[j]);
                         output[i * 3 * 4 + j * 4 + 0] = vertex.x;
                         output[i * 3 * 4 + j * 4 + 1] = vertex.y;
                         output[i * 3 * 4 + j * 4 + 2] = vertex.z;
@@ -324,10 +325,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 4);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = state.modelLoader->GetFace(i + groupOffset);
+                  auto face = modelLoader.GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto normal = state.modelLoader->GetNormal(face.normalIndex[j]);
+                        auto normal = modelLoader.GetNormal(face.normalIndex[j]);
                         output[i * 3 * 4 + j * 4 + 0] = normal.x;
                         output[i * 3 * 4 + j * 4 + 1] = normal.y;
                         output[i * 3 * 4 + j * 4 + 2] = normal.z;
@@ -340,10 +341,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 4);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = state.modelLoader->GetFace(i + groupOffset);
+                  auto face = modelLoader.GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto tangent = state.modelLoader->GetTangent(face.normalIndex[j]);
+                        auto tangent = modelLoader.GetTangent(face.normalIndex[j]);
                         output[i * 3 * 4 + j * 4 + 0] = tangent.x;
                         output[i * 3 * 4 + j * 4 + 1] = tangent.y;
                         output[i * 3 * 4 + j * 4 + 2] = tangent.z;
@@ -356,10 +357,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 2);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = state.modelLoader->GetFace(i + groupOffset);
+                  auto face = modelLoader.GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto texCoord = state.modelLoader->GetTextureCoord(face.textureIndex[j]);
+                        auto texCoord = modelLoader.GetTextureCoord(face.textureIndex[j]);
                         output[i * 3 * 2 + j * 2 + 0] = texCoord.x;
                         output[i * 3 * 2 + j * 2 + 1] = texCoord.y;
                   }
@@ -386,7 +387,7 @@ AssetSuite::ErrorCode AssetSuite::Manager::DumpDecodedBuffer()
 void AssetSuite::Manager::StoreImageToFile(const std::string& filePathAndName, const std::vector<BYTE>& buffer, const ImageDescriptor& imageDescriptor)
 {
       auto& state = State();
-      state.rawBuffer = state.ppmEncoder->Encode(buffer, imageDescriptor);
+      state.rawBuffer = state.codecs.ppmEncoder->Encode(buffer, imageDescriptor);
       StoreMemoryToFile(state.rawBuffer, filePathAndName);
 }
 
@@ -420,6 +421,6 @@ void AssetSuite::Manager::DumpByteVectorToCpp(const std::vector<BYTE>& byteVecto
 
 void AssetSuite::Manager::DumpBuffer(const std::string& fileName, const std::vector<BYTE>& buffer, ImageDescriptor& descriptor)
 {
-      auto dumpBuffer = State().bypassEncoder->Encode(buffer, descriptor);
+      auto dumpBuffer = State().codecs.bypassEncoder->Encode(buffer, descriptor);
       StoreMemoryToFile(dumpBuffer, fileName);
 }

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -3,6 +3,7 @@
 #include "AssetSuite.h"
 #include "AssetSuiteContext.h"
 
+#include "../runtime/AssetSuiteRuntime.h"
 #include "../wavefront/ModelLoader.h"
 #include "../bmp/BmpDecoder.h"
 #include "../png/PngDecoder.h"
@@ -137,9 +138,7 @@ AssetSuite::Result AssetSuite::SetLoggingCallback(
 		return Result::ErrorInvalidContext;
 	}
 
-	context->loggingCallback = callback;
-	context->minimumLogLevel = minLevel;
-	context->loggingUserData = userData;
+	context->Runtime().SetLoggingCallback(callback, minLevel, userData);
 	return Result::Success;
 }
 

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -102,32 +102,12 @@ AssetSuite::Result AssetSuite::CreateContext(const ContextDesc* desc, ContextHan
 		return validationResult;
 	}
 
-	try
-	{
-		*outContext = new AssetSuiteContext_t(normalizedDesc);
-	}
-	catch (const std::bad_alloc&)
-	{
-		return Result::ErrorOutOfMemory;
-	}
-	catch (...)
-	{
-		return Result::ErrorUnknown;
-	}
-
-	return Result::Success;
+	return Internal::CreateContextHandle(normalizedDesc, outContext);
 }
 
 AssetSuite::Result AssetSuite::DestroyContext(ContextHandle* context)
 {
-	if (!context || !*context)
-	{
-		return Result::ErrorInvalidContext;
-	}
-
-	delete *context;
-	*context = nullptr;
-	return Result::Success;
+	return Internal::DestroyContextHandle(context);
 }
 
 AssetSuite::Result AssetSuite::SetLoggingCallback(

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -11,6 +11,8 @@
 #include "../ppm/PpmEncoder.h"
 #include "../bypass/BypassEncoder.h"
 
+#include <fstream>
+#include <iostream>
 #include <new>
 
 namespace
@@ -208,22 +210,23 @@ AssetSuite::ErrorCode AssetSuite::Manager::ImageDecode(ImageDecoders decoder)
 
       if (decoder == ImageDecoders::Auto)
       {
-            if (state.fileInfo.extension.compare(".bmp") == 0)
+            decoder = state.codecRegistry.ResolveImageDecoder(state.fileInfo.extension);
+            if (decoder == ImageDecoders::Auto)
             {
-                  decoder = ImageDecoders::BMP;
-            }
-            else if (state.fileInfo.extension.compare(".png") == 0)
-            {
-                  decoder = ImageDecoders::PNG;
-            }
-            else
-            {
+                  state.diagnostics.Add(ErrorCode::FileTypeNotSupported, "Image file type is not supported.");
                   return ErrorCode::FileTypeNotSupported;
             }
       }
 
+      ImageDecoder* imageDecoder = state.codecRegistry.FindImageDecoder(decoder);
+      if (!imageDecoder)
+      {
+            state.diagnostics.Add(ErrorCode::FileTypeNotSupported, "Image decoder is not registered.");
+            return ErrorCode::FileTypeNotSupported;
+      }
+
       ImageDescriptor descriptor;
-      auto error = state.imageDecoders[(size_t)decoder]->Decode(state.decodedBuffer, state.rawBuffer.data(), descriptor);
+      auto error = imageDecoder->Decode(state.decodedBuffer, state.rawBuffer.data(), descriptor);
 
       state.imageInfo.width = descriptor.width;
       state.imageInfo.height = descriptor.height;
@@ -287,19 +290,24 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshDecode(MeshDecoders decoder)
 
       if (decoder == MeshDecoders::Auto)
       {
-            if (state.fileInfo.extension.compare(".obj") == 0)
+            decoder = state.codecRegistry.ResolveMeshDecoder(state.fileInfo.extension);
+            if (decoder == MeshDecoders::Auto)
             {
-                  decoder = MeshDecoders::WAVEFRONT;
-            }
-            else
-            {
+                  state.diagnostics.Add(ErrorCode::FileTypeNotSupported, "Mesh file type is not supported.");
                   return ErrorCode::FileTypeNotSupported;
             }
       }
 
+      MeshDecoder* meshDecoder = state.codecRegistry.FindMeshDecoder(decoder);
+      if (!meshDecoder)
+      {
+            state.diagnostics.Add(ErrorCode::FileTypeNotSupported, "Mesh decoder is not registered.");
+            return ErrorCode::FileTypeNotSupported;
+      }
+
       std::vector<BYTE> output;
       MeshDescriptor descriptor;
-      auto error = state.meshDecoders[(size_t)decoder]->Decode(output, state.rawBuffer.data(), descriptor);
+      auto error = meshDecoder->Decode(output, state.rawBuffer.data(), descriptor);
       return error ? ErrorCode::OK : ErrorCode::Undefined;
 }
 
@@ -404,62 +412,14 @@ void AssetSuite::Manager::StoreImageToFile(const std::string& filePathAndName, c
 
 AssetSuite::ErrorCode AssetSuite::Manager::LoadFileToMemory(const std::string& fileName, bool isBinary)
 {
-      // Check if file exists
       auto& state = State();
-      if (!std::filesystem::exists(state.fileInfo.fullName))
+      const ErrorCode result = state.fileLoader.LoadToMemory(fileName, isBinary, state.rawBuffer);
+      if (result != ErrorCode::OK)
       {
-            return ErrorCode::NonExistingFile;
+            state.diagnostics.Add(result, "Failed to load file into runtime memory.");
       }
 
-      // Clear the buffer, since it might have something in it
-      state.rawBuffer.clear();
-
-      //load and decode
-      std::ifstream file(fileName.c_str(), std::ios::in | std::ios::ate | std::ios::binary);
-
-      // Figure out the file size
-      // - this type is an implementation-defined signed integral type used to represent the number of
-      //   characters transered in an I/O opration or the size of I/O buffer. It is usead as a ssinged counterpart of the std:size_T
-      std::streamsize size = 0;
-
-      // - seekg sets the position of the next character to be extracted from the input stream
-      // - it returns the istream object
-      // - first parameter is the offset value, relative to the second parameter
-      // - second parameter can take three values: beginning, current or end of the current stream
-      // - this seems to set the next character to read as the last character in the file
-      if (file.seekg(0, std::ios::end).good())
-      {
-            // tellg() returns the position of the currenct character in the input stream
-            // the return type is the streampos
-            // effectively this returns the position of the last character
-            size = file.tellg();
-      }
-
-      // this seems to set the next character to read as the first character
-      if (file.seekg(0, std::ios::beg).good())
-      {
-            // tellg() function returns the position of the first character
-            // you calculate the size of the file by substracting position of the last character from the first character
-            size -= file.tellg();
-      }
-
-      //read contents of the file into the vector
-      if (size > 0)
-      {
-            state.rawBuffer.resize((size_t)size);
-            file.read((char*)(&state.rawBuffer[0]), size);
-            if (!isBinary)
-            {
-                  // Needed for stringstream to work properly.
-                  state.rawBuffer.push_back('\0');
-            }
-      }
-      else
-      {
-            state.rawBuffer.clear();
-      }
-
-      return ErrorCode::OK;
+      return result;
 }
 
 void AssetSuite::Manager::StoreMemoryToFile(const std::vector<BYTE>& buffer, const std::string& fileName)

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -4,6 +4,7 @@
 #include "AssetSuiteContext.h"
 
 #include "../runtime/AssetSuiteRuntime.h"
+#include "../runtime/AssetSuiteRuntimeState.h"
 #include "../wavefront/ModelLoader.h"
 #include "../bmp/BmpDecoder.h"
 #include "../png/PngDecoder.h"
@@ -142,46 +143,34 @@ AssetSuite::Result AssetSuite::SetLoggingCallback(
 	return Result::Success;
 }
 
-AssetSuite::Manager::Manager() : modelLoader(nullptr), imageInfo(), meshInfo()
+AssetSuite::Manager::Manager()
+	: runtimeState(new Internal::RuntimeState())
+	, ownsRuntimeState(true)
 {
-	modelLoader = new ModelLoader;
-      bmpDecoder = new BmpDecoder;
-      pngDecoder = new PngDecoder;
-      ppmEncoder = new PpmEncoder;
-      bypassEncoder = new BypassEncoder;
+}
 
-      imageDecoders[(size_t)ImageDecoders::BMP] = bmpDecoder;
-      imageDecoders[(size_t)ImageDecoders::PNG] = pngDecoder;
-
-      meshDecoders[(size_t)MeshDecoders::WAVEFRONT] = modelLoader;
+AssetSuite::Manager::Manager(Internal::RuntimeState& runtimeState)
+	: runtimeState(&runtimeState)
+	, ownsRuntimeState(false)
+{
 }
 
 AssetSuite::Manager::~Manager()
 {
-      if (bypassEncoder)
-      {
-            delete bypassEncoder;
-      }
-
-      if (ppmEncoder)
-      {
-            delete ppmEncoder;
-      }
-
-      if (pngDecoder)
-      {
-            delete pngDecoder;
-      }
-
-      if (bmpDecoder)
-      {
-            delete bmpDecoder;
-      }
-
-	if (modelLoader)
+	if (ownsRuntimeState)
 	{
-		delete modelLoader;
+		delete runtimeState;
 	}
+}
+
+AssetSuite::Internal::RuntimeState& AssetSuite::Manager::State()
+{
+	return *runtimeState;
+}
+
+const AssetSuite::Internal::RuntimeState& AssetSuite::Manager::State() const
+{
+	return *runtimeState;
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::ImageLoadAndDecode(const char* filePathAndName, ImageDecoders decoder)
@@ -203,25 +192,27 @@ AssetSuite::ErrorCode AssetSuite::Manager::ImageLoadAndDecode(const char* filePa
 
 AssetSuite::ErrorCode AssetSuite::Manager::ImageLoad(const char* filePathAndName)
 {
-      fileInfo.fullName = filePathAndName;
-      fileInfo.extension = fileInfo.fullName.extension();
+      auto& state = State();
+      state.fileInfo.fullName = filePathAndName;
+      state.fileInfo.extension = state.fileInfo.fullName.extension();
       return LoadFileToMemory(filePathAndName);
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::ImageDecode(ImageDecoders decoder)
 {
-      if (rawBuffer.empty())
+      auto& state = State();
+      if (state.rawBuffer.empty())
       {
             return ErrorCode::RawBufferIsEmpty;
       }
 
       if (decoder == ImageDecoders::Auto)
       {
-            if (fileInfo.extension.compare(".bmp") == 0)
+            if (state.fileInfo.extension.compare(".bmp") == 0)
             {
                   decoder = ImageDecoders::BMP;
             }
-            else if (fileInfo.extension.compare(".png") == 0)
+            else if (state.fileInfo.extension.compare(".png") == 0)
             {
                   decoder = ImageDecoders::PNG;
             }
@@ -232,26 +223,27 @@ AssetSuite::ErrorCode AssetSuite::Manager::ImageDecode(ImageDecoders decoder)
       }
 
       ImageDescriptor descriptor;
-      auto error = imageDecoders[(size_t)decoder]->Decode(decodedBuffer, rawBuffer.data(), descriptor);
+      auto error = state.imageDecoders[(size_t)decoder]->Decode(state.decodedBuffer, state.rawBuffer.data(), descriptor);
 
-      imageInfo.width = descriptor.width;
-      imageInfo.height = descriptor.height;
-      imageInfo.format = descriptor.format;
+      state.imageInfo.width = descriptor.width;
+      state.imageInfo.height = descriptor.height;
+      state.imageInfo.format = descriptor.format;
 
       return error ? ErrorCode::OK : ErrorCode::Undefined;
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::ImageGet(OutputFormat format, std::vector<BYTE>& output, ImageDescriptor& descriptor)
 {
-      if (decodedBuffer.empty())
+      const auto& state = State();
+      if (state.decodedBuffer.empty())
       {
             return ErrorCode::DecodedBufferIsEmpty;
       }
 
-      output = decodedBuffer;
-      descriptor.width = imageInfo.width;
-      descriptor.height = imageInfo.height;
-      descriptor.format = imageInfo.format;
+      output = state.decodedBuffer;
+      descriptor.width = state.imageInfo.width;
+      descriptor.height = state.imageInfo.height;
+      descriptor.format = state.imageInfo.format;
 
       return ErrorCode::OK;
 }
@@ -279,21 +271,23 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshLoadAndDecode(const char* filePat
 
 AssetSuite::ErrorCode AssetSuite::Manager::MeshLoad(const char* filePathAndName)
 {
-      fileInfo.fullName = filePathAndName;
-      fileInfo.extension = fileInfo.fullName.extension();
+      auto& state = State();
+      state.fileInfo.fullName = filePathAndName;
+      state.fileInfo.extension = state.fileInfo.fullName.extension();
       return LoadFileToMemory(filePathAndName, false);
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::MeshDecode(MeshDecoders decoder)
 {
-      if (rawBuffer.empty())
+      auto& state = State();
+      if (state.rawBuffer.empty())
       {
             return ErrorCode::RawBufferIsEmpty;
       }
 
       if (decoder == MeshDecoders::Auto)
       {
-            if (fileInfo.extension.compare(".obj") == 0)
+            if (state.fileInfo.extension.compare(".obj") == 0)
             {
                   decoder = MeshDecoders::WAVEFRONT;
             }
@@ -305,19 +299,20 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshDecode(MeshDecoders decoder)
 
       std::vector<BYTE> output;
       MeshDescriptor descriptor;
-      auto error = meshDecoders[(size_t)decoder]->Decode(output, rawBuffer.data(), descriptor);
+      auto error = state.meshDecoders[(size_t)decoder]->Decode(output, state.rawBuffer.data(), descriptor);
       return error ? ErrorCode::OK : ErrorCode::Undefined;
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOutputFormat format, std::vector<FLOAT>& output, MeshDescriptor& descriptor)
 {
+      auto& state = State();
       // Fetch the group data
-      auto groupOffset = modelLoader->GetGroupOffset(meshName);
-      auto groupSize = modelLoader->GetGroupSize(meshName);
-      meshInfo.numOfVertices = groupSize;
-      meshInfo.numOfIndices = groupSize;
-      descriptor.numOfVertices = meshInfo.numOfVertices;
-      descriptor.numOfIndices = meshInfo.numOfIndices;
+      auto groupOffset = state.modelLoader->GetGroupOffset(meshName);
+      auto groupSize = state.modelLoader->GetGroupSize(meshName);
+      state.meshInfo.numOfVertices = groupSize;
+      state.meshInfo.numOfIndices = groupSize;
+      descriptor.numOfVertices = state.meshInfo.numOfVertices;
+      descriptor.numOfIndices = state.meshInfo.numOfIndices;
 
       if (format == MeshOutputFormat::POSITION)
       {
@@ -325,10 +320,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 4);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = modelLoader->GetFace(i + groupOffset);
+                  auto face = state.modelLoader->GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto vertex = modelLoader->GetVertex(face.vertexIndex[j]);
+                        auto vertex = state.modelLoader->GetVertex(face.vertexIndex[j]);
                         output[i * 3 * 4 + j * 4 + 0] = vertex.x;
                         output[i * 3 * 4 + j * 4 + 1] = vertex.y;
                         output[i * 3 * 4 + j * 4 + 2] = vertex.z;
@@ -341,10 +336,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 4);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = modelLoader->GetFace(i + groupOffset);
+                  auto face = state.modelLoader->GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto normal = modelLoader->GetNormal(face.normalIndex[j]);
+                        auto normal = state.modelLoader->GetNormal(face.normalIndex[j]);
                         output[i * 3 * 4 + j * 4 + 0] = normal.x;
                         output[i * 3 * 4 + j * 4 + 1] = normal.y;
                         output[i * 3 * 4 + j * 4 + 2] = normal.z;
@@ -357,10 +352,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 4);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = modelLoader->GetFace(i + groupOffset);
+                  auto face = state.modelLoader->GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto tangent = modelLoader->GetTangent(face.normalIndex[j]);
+                        auto tangent = state.modelLoader->GetTangent(face.normalIndex[j]);
                         output[i * 3 * 4 + j * 4 + 0] = tangent.x;
                         output[i * 3 * 4 + j * 4 + 1] = tangent.y;
                         output[i * 3 * 4 + j * 4 + 2] = tangent.z;
@@ -373,10 +368,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
             output.resize(groupSize * 3 * 2);
             for (UINT i = 0; i < groupSize; i++)
             {
-                  auto face = modelLoader->GetFace(i + groupOffset);
+                  auto face = state.modelLoader->GetFace(i + groupOffset);
                   for (int j = 0; j < 3; j++)
                   {
-                        auto texCoord = modelLoader->GetTextureCoord(face.textureIndex[j]);
+                        auto texCoord = state.modelLoader->GetTextureCoord(face.textureIndex[j]);
                         output[i * 3 * 2 + j * 2 + 0] = texCoord.x;
                         output[i * 3 * 2 + j * 2 + 1] = texCoord.y;
                   }
@@ -389,33 +384,35 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshGet(const char* meshName, MeshOut
 AssetSuite::ErrorCode AssetSuite::Manager::DumpRawBuffer()
 {
       ImageDescriptor descriptor;
-      DumpBuffer("rawBuffer.txt", rawBuffer, descriptor);
+      DumpBuffer("rawBuffer.txt", State().rawBuffer, descriptor);
       return ErrorCode::OK;
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::DumpDecodedBuffer()
 {
       ImageDescriptor descriptor;
-      DumpBuffer("decodedBuffer.txt", decodedBuffer, descriptor);
+      DumpBuffer("decodedBuffer.txt", State().decodedBuffer, descriptor);
       return ErrorCode::OK;
 }
 
 void AssetSuite::Manager::StoreImageToFile(const std::string& filePathAndName, const std::vector<BYTE>& buffer, const ImageDescriptor& imageDescriptor)
 {
-      this->rawBuffer = ppmEncoder->Encode(buffer, imageDescriptor);
-      StoreMemoryToFile(this->rawBuffer, filePathAndName);
+      auto& state = State();
+      state.rawBuffer = state.ppmEncoder->Encode(buffer, imageDescriptor);
+      StoreMemoryToFile(state.rawBuffer, filePathAndName);
 }
 
 AssetSuite::ErrorCode AssetSuite::Manager::LoadFileToMemory(const std::string& fileName, bool isBinary)
 {
       // Check if file exists
-      if (!std::filesystem::exists(fileInfo.fullName))
+      auto& state = State();
+      if (!std::filesystem::exists(state.fileInfo.fullName))
       {
             return ErrorCode::NonExistingFile;
       }
 
       // Clear the buffer, since it might have something in it
-      rawBuffer.clear();
+      state.rawBuffer.clear();
 
       //load and decode
       std::ifstream file(fileName.c_str(), std::ios::in | std::ios::ate | std::ios::binary);
@@ -449,17 +446,17 @@ AssetSuite::ErrorCode AssetSuite::Manager::LoadFileToMemory(const std::string& f
       //read contents of the file into the vector
       if (size > 0)
       {
-            rawBuffer.resize((size_t)size);
-            file.read((char*)(&rawBuffer[0]), size);
+            state.rawBuffer.resize((size_t)size);
+            file.read((char*)(&state.rawBuffer[0]), size);
             if (!isBinary)
             {
                   // Needed for stringstream to work properly.
-                  rawBuffer.push_back('\0');
+                  state.rawBuffer.push_back('\0');
             }
       }
       else
       {
-            rawBuffer.clear();
+            state.rawBuffer.clear();
       }
 
       return ErrorCode::OK;
@@ -483,6 +480,6 @@ void AssetSuite::Manager::DumpByteVectorToCpp(const std::vector<BYTE>& byteVecto
 
 void AssetSuite::Manager::DumpBuffer(const std::string& fileName, const std::vector<BYTE>& buffer, ImageDescriptor& descriptor)
 {
-      auto dumpBuffer = bypassEncoder->Encode(buffer, descriptor);
+      auto dumpBuffer = State().bypassEncoder->Encode(buffer, descriptor);
       StoreMemoryToFile(dumpBuffer, fileName);
 }

--- a/source/common/AssetSuite.h
+++ b/source/common/AssetSuite.h
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <filesystem>
 #include <Windows.h>
 
 #include <AssetSuite/AssetSuite.h>
@@ -23,6 +22,10 @@ namespace AssetSuite
 	class PngDecoder;
 	class PpmEncoder;
 	class BypassEncoder;
+	namespace Internal
+	{
+		struct RuntimeState;
+	}
 
 	enum class ASSET_SUITE_EXPORTS ImageDecoders
 	{
@@ -75,7 +78,11 @@ namespace AssetSuite
 	{
 	public:
 		Manager();
+		explicit Manager(Internal::RuntimeState& runtimeState);
 		~Manager();
+
+		Manager(const Manager&) = delete;
+		Manager& operator=(const Manager&) = delete;
 		
 		void StoreImageToFile(const std::string& filePathAndName, const std::vector<BYTE>& buffer, const ImageDescriptor& imageDescriptor);
 		ErrorCode ImageLoadAndDecode(const char* filePathAndName, ImageDecoders decoder = ImageDecoders::Auto);
@@ -92,38 +99,15 @@ namespace AssetSuite
 		ErrorCode DumpRawBuffer();
 		ErrorCode DumpDecodedBuffer();
 	private:
-		struct FileInfo
-		{
-			std::filesystem::path fullName;
-			std::filesystem::path extension;
-		};
-		struct ImageInfo
-		{
-			UINT width;
-			UINT height;
-			ImageFormat format;
-		};
-		struct MeshInfo
-		{
-			UINT numOfVertices;
-			UINT numOfIndices;
-		};
+		Internal::RuntimeState& State();
+		const Internal::RuntimeState& State() const;
+
 		ErrorCode LoadFileToMemory(const std::string& fileName, bool isBinary = true);
 		void StoreMemoryToFile(const std::vector<BYTE>& buffer, const std::string& fileName);
 		void DumpByteVectorToCpp(const std::vector<BYTE>& byteVector);
 		void DumpBuffer(const std::string& fileName, const std::vector<BYTE>& buffer, ImageDescriptor& descriptor);
-		FileInfo fileInfo;
-		ImageInfo imageInfo;
-		MeshInfo meshInfo;
-		std::vector<BYTE> rawBuffer;
-		std::vector<BYTE> decodedBuffer;
-		std::vector<BYTE> formattedBuffer;
-		ModelLoader* modelLoader;
-		BmpDecoder* bmpDecoder;
-		PngDecoder* pngDecoder;
-		PpmEncoder* ppmEncoder;
-		BypassEncoder* bypassEncoder;
-		ImageDecoder* imageDecoders[(size_t)ImageDecoders::MaxDecoders];
-		MeshDecoder* meshDecoders[(size_t)MeshDecoders::MaxDecoders];
+
+		Internal::RuntimeState* runtimeState;
+		bool ownsRuntimeState;
 	};
 }

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -64,6 +64,7 @@ AssetSuite::Result AssetSuite::Internal::DestroyContextHandle(ContextHandle* con
 	return Result::Success;
 }
 
+#if !defined(ASSETSUITE_UNIT_TEST_PRIVATE_RUNTIME)
 void AssetSuite::DispatchLogEvent(ContextHandle context, LogLevel level, const char* message)
 {
 	if (!context)
@@ -73,55 +74,4 @@ void AssetSuite::DispatchLogEvent(ContextHandle context, LogLevel level, const c
 
 	context->Runtime().DispatchLogEvent(level, message);
 }
-
-AssetSuite::Result AssetSuite::CaptureRuntimeSmokeStatus(ContextHandle context, RuntimeSmokeStatus* outStatus)
-{
-	if (!context)
-	{
-		return Result::ErrorInvalidContext;
-	}
-
-	if (!outStatus)
-	{
-		return Result::ErrorInvalidArgument;
-	}
-
-	auto& runtime = context->Runtime();
-	auto& codecRegistry = runtime.CodecRegistry();
-	outStatus->descriptorStructSize = runtime.Descriptor().structSize;
-	outStatus->descriptorFlags = runtime.Descriptor().flags;
-	outStatus->diagnosticsEntryCount = static_cast<uint32_t>(runtime.Diagnostics().Entries().size());
-	outStatus->hasBmpDecoder = codecRegistry.FindImageDecoder(ImageDecoders::BMP) != nullptr;
-	outStatus->hasPngDecoder = codecRegistry.FindImageDecoder(ImageDecoders::PNG) != nullptr;
-	outStatus->hasWavefrontDecoder = codecRegistry.FindMeshDecoder(MeshDecoders::WAVEFRONT) != nullptr;
-	outStatus->rejectsImageSentinels =
-		codecRegistry.FindImageDecoder(ImageDecoders::Auto) == nullptr &&
-		codecRegistry.FindImageDecoder(ImageDecoders::MaxDecoders) == nullptr;
-	outStatus->rejectsMeshSentinels =
-		codecRegistry.FindMeshDecoder(MeshDecoders::Auto) == nullptr &&
-		codecRegistry.FindMeshDecoder(MeshDecoders::MaxDecoders) == nullptr;
-
-	return Result::Success;
-}
-
-AssetSuite::Result AssetSuite::AddRuntimeSmokeDiagnostic(ContextHandle context)
-{
-	if (!context)
-	{
-		return Result::ErrorInvalidContext;
-	}
-
-	context->Runtime().Diagnostics().Add(ErrorCode::Undefined, "runtime smoke diagnostic");
-	return Result::Success;
-}
-
-AssetSuite::Result AssetSuite::ClearRuntimeSmokeDiagnostics(ContextHandle context)
-{
-	if (!context)
-	{
-		return Result::ErrorInvalidContext;
-	}
-
-	context->Runtime().Diagnostics().Clear();
-	return Result::Success;
-}
+#endif

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -1,1 +1,30 @@
 #include "AssetSuiteContext.h"
+
+#include "../runtime/AssetSuiteRuntime.h"
+
+AssetSuite::AssetSuiteContext_t::AssetSuiteContext_t(const ContextDesc& desc)
+	: runtime(std::make_unique<Internal::RuntimeContext>(desc))
+{
+}
+
+AssetSuite::AssetSuiteContext_t::~AssetSuiteContext_t() = default;
+
+AssetSuite::Internal::RuntimeContext& AssetSuite::AssetSuiteContext_t::Runtime()
+{
+	return *runtime;
+}
+
+const AssetSuite::Internal::RuntimeContext& AssetSuite::AssetSuiteContext_t::Runtime() const
+{
+	return *runtime;
+}
+
+void AssetSuite::DispatchLogEvent(ContextHandle context, LogLevel level, const char* message)
+{
+	if (!context)
+	{
+		return;
+	}
+
+	context->Runtime().DispatchLogEvent(level, message);
+}

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -2,6 +2,8 @@
 
 #include "../runtime/AssetSuiteRuntime.h"
 
+#include <new>
+
 AssetSuite::AssetSuiteContext_t::AssetSuiteContext_t(const ContextDesc& desc)
 	: runtime(std::make_unique<Internal::RuntimeContext>(desc))
 {
@@ -17,6 +19,47 @@ AssetSuite::Internal::RuntimeContext& AssetSuite::AssetSuiteContext_t::Runtime()
 const AssetSuite::Internal::RuntimeContext& AssetSuite::AssetSuiteContext_t::Runtime() const
 {
 	return *runtime;
+}
+
+AssetSuite::Result AssetSuite::Internal::CreateContextHandle(
+	const ContextDesc& desc,
+	ContextHandle* outContext) noexcept
+{
+	try
+	{
+		std::unique_ptr<AssetSuiteContext_t> context = std::make_unique<AssetSuiteContext_t>(desc);
+		*outContext = context.release();
+	}
+	catch (const std::bad_alloc&)
+	{
+		return Result::ErrorOutOfMemory;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
+	}
+
+	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::Internal::DestroyContextHandle(ContextHandle* context) noexcept
+{
+	if (!context || !*context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	try
+	{
+		delete *context;
+		*context = nullptr;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
+	}
+
+	return Result::Success;
 }
 
 void AssetSuite::DispatchLogEvent(ContextHandle context, LogLevel level, const char* message)

--- a/source/common/AssetSuiteContext.cpp
+++ b/source/common/AssetSuiteContext.cpp
@@ -2,6 +2,8 @@
 
 #include "../runtime/AssetSuiteRuntime.h"
 
+#include "AssetSuite.h"
+
 #include <new>
 
 AssetSuite::AssetSuiteContext_t::AssetSuiteContext_t(const ContextDesc& desc)
@@ -70,4 +72,56 @@ void AssetSuite::DispatchLogEvent(ContextHandle context, LogLevel level, const c
 	}
 
 	context->Runtime().DispatchLogEvent(level, message);
+}
+
+AssetSuite::Result AssetSuite::CaptureRuntimeSmokeStatus(ContextHandle context, RuntimeSmokeStatus* outStatus)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!outStatus)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	auto& runtime = context->Runtime();
+	auto& codecRegistry = runtime.CodecRegistry();
+	outStatus->descriptorStructSize = runtime.Descriptor().structSize;
+	outStatus->descriptorFlags = runtime.Descriptor().flags;
+	outStatus->diagnosticsEntryCount = static_cast<uint32_t>(runtime.Diagnostics().Entries().size());
+	outStatus->hasBmpDecoder = codecRegistry.FindImageDecoder(ImageDecoders::BMP) != nullptr;
+	outStatus->hasPngDecoder = codecRegistry.FindImageDecoder(ImageDecoders::PNG) != nullptr;
+	outStatus->hasWavefrontDecoder = codecRegistry.FindMeshDecoder(MeshDecoders::WAVEFRONT) != nullptr;
+	outStatus->rejectsImageSentinels =
+		codecRegistry.FindImageDecoder(ImageDecoders::Auto) == nullptr &&
+		codecRegistry.FindImageDecoder(ImageDecoders::MaxDecoders) == nullptr;
+	outStatus->rejectsMeshSentinels =
+		codecRegistry.FindMeshDecoder(MeshDecoders::Auto) == nullptr &&
+		codecRegistry.FindMeshDecoder(MeshDecoders::MaxDecoders) == nullptr;
+
+	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::AddRuntimeSmokeDiagnostic(ContextHandle context)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	context->Runtime().Diagnostics().Add(ErrorCode::Undefined, "runtime smoke diagnostic");
+	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::ClearRuntimeSmokeDiagnostics(ContextHandle context)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	context->Runtime().Diagnostics().Clear();
+	return Result::Success;
 }

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -26,20 +26,5 @@ namespace AssetSuite
 		std::unique_ptr<Internal::RuntimeContext> runtime;
 	};
 
-	struct RuntimeSmokeStatus
-	{
-		uint32_t descriptorStructSize;
-		uint32_t descriptorFlags;
-		uint32_t diagnosticsEntryCount;
-		bool hasBmpDecoder;
-		bool hasPngDecoder;
-		bool hasWavefrontDecoder;
-		bool rejectsImageSentinels;
-		bool rejectsMeshSentinels;
-	};
-
 	ASSET_SUITE_API void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message);
-	ASSET_SUITE_API Result CaptureRuntimeSmokeStatus(ContextHandle context, RuntimeSmokeStatus* outStatus);
-	ASSET_SUITE_API Result AddRuntimeSmokeDiagnostic(ContextHandle context);
-	ASSET_SUITE_API Result ClearRuntimeSmokeDiagnostics(ContextHandle context);
 }

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -9,6 +9,9 @@ namespace AssetSuite
 	namespace Internal
 	{
 		class RuntimeContext;
+
+		Result CreateContextHandle(const ContextDesc& desc, ContextHandle* outContext) noexcept;
+		Result DestroyContextHandle(ContextHandle* context) noexcept;
 	}
 
 	struct AssetSuiteContext_t

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -1,39 +1,27 @@
 #pragma once
 
-#include "AssetSuite.h"
+#include <memory>
+
+#include <AssetSuite/AssetSuite.h>
 
 namespace AssetSuite
 {
+	namespace Internal
+	{
+		class RuntimeContext;
+	}
+
 	struct AssetSuiteContext_t
 	{
-		explicit AssetSuiteContext_t(const ContextDesc& desc)
-			: desc(desc)
-			, manager()
-			, loggingCallback(nullptr)
-			, minimumLogLevel(LogLevel::Info)
-			, loggingUserData(nullptr)
-		{
-		}
+		explicit AssetSuiteContext_t(const ContextDesc& desc);
+		~AssetSuiteContext_t();
 
-		ContextDesc desc;
-		Manager manager;
-		LoggingCallback loggingCallback;
-		LogLevel minimumLogLevel;
-		void* loggingUserData;
+		Internal::RuntimeContext& Runtime();
+		const Internal::RuntimeContext& Runtime() const;
+
+	private:
+		std::unique_ptr<Internal::RuntimeContext> runtime;
 	};
 
-	inline void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message)
-	{
-		if (!context || !context->loggingCallback || !message)
-		{
-			return;
-		}
-
-		if (static_cast<uint32_t>(level) < static_cast<uint32_t>(context->minimumLogLevel))
-		{
-			return;
-		}
-
-		context->loggingCallback(level, message, context->loggingUserData);
-	}
+	ASSET_SUITE_API void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message);
 }

--- a/source/common/AssetSuiteContext.h
+++ b/source/common/AssetSuiteContext.h
@@ -26,5 +26,20 @@ namespace AssetSuite
 		std::unique_ptr<Internal::RuntimeContext> runtime;
 	};
 
+	struct RuntimeSmokeStatus
+	{
+		uint32_t descriptorStructSize;
+		uint32_t descriptorFlags;
+		uint32_t diagnosticsEntryCount;
+		bool hasBmpDecoder;
+		bool hasPngDecoder;
+		bool hasWavefrontDecoder;
+		bool rejectsImageSentinels;
+		bool rejectsMeshSentinels;
+	};
+
 	ASSET_SUITE_API void DispatchLogEvent(ContextHandle context, LogLevel level, const char* message);
+	ASSET_SUITE_API Result CaptureRuntimeSmokeStatus(ContextHandle context, RuntimeSmokeStatus* outStatus);
+	ASSET_SUITE_API Result AddRuntimeSmokeDiagnostic(ContextHandle context);
+	ASSET_SUITE_API Result ClearRuntimeSmokeDiagnostics(ContextHandle context);
 }

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -25,6 +25,42 @@ const AssetSuite::Manager& AssetSuite::Internal::RuntimeContext::LegacyManager()
 	return manager;
 }
 
+AssetSuite::Internal::RuntimeState::AllocatorPolicy&
+AssetSuite::Internal::RuntimeContext::AllocatorPolicy() noexcept
+{
+	return state.allocatorPolicy;
+}
+
+AssetSuite::Internal::RuntimeState::Diagnostics&
+AssetSuite::Internal::RuntimeContext::Diagnostics() noexcept
+{
+	return state.diagnostics;
+}
+
+const AssetSuite::Internal::RuntimeState::Diagnostics&
+AssetSuite::Internal::RuntimeContext::Diagnostics() const noexcept
+{
+	return state.diagnostics;
+}
+
+AssetSuite::Internal::RuntimeState::FileLoader&
+AssetSuite::Internal::RuntimeContext::FileLoader() noexcept
+{
+	return state.fileLoader;
+}
+
+AssetSuite::Internal::RuntimeState::CodecRegistry&
+AssetSuite::Internal::RuntimeContext::CodecRegistry() noexcept
+{
+	return state.codecRegistry;
+}
+
+const AssetSuite::Internal::RuntimeState::CodecRegistry&
+AssetSuite::Internal::RuntimeContext::CodecRegistry() const noexcept
+{
+	return state.codecRegistry;
+}
+
 void AssetSuite::Internal::RuntimeContext::SetLoggingCallback(
 	LoggingCallback callback,
 	LogLevel minimumLevel,

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -1,0 +1,50 @@
+#include "AssetSuiteRuntime.h"
+
+AssetSuite::Internal::RuntimeContext::RuntimeContext(const ContextDesc& desc)
+	: desc(desc)
+	, manager()
+	, logging()
+{
+}
+
+AssetSuite::Internal::RuntimeContext::~RuntimeContext() = default;
+
+const AssetSuite::ContextDesc& AssetSuite::Internal::RuntimeContext::Descriptor() const noexcept
+{
+	return desc;
+}
+
+AssetSuite::Manager& AssetSuite::Internal::RuntimeContext::LegacyManager() noexcept
+{
+	return manager;
+}
+
+const AssetSuite::Manager& AssetSuite::Internal::RuntimeContext::LegacyManager() const noexcept
+{
+	return manager;
+}
+
+void AssetSuite::Internal::RuntimeContext::SetLoggingCallback(
+	LoggingCallback callback,
+	LogLevel minimumLevel,
+	void* userData) noexcept
+{
+	logging.callback = callback;
+	logging.minimumLevel = minimumLevel;
+	logging.userData = userData;
+}
+
+void AssetSuite::Internal::RuntimeContext::DispatchLogEvent(LogLevel level, const char* message) const
+{
+	if (!logging.callback || !message)
+	{
+		return;
+	}
+
+	if (static_cast<uint32_t>(level) < static_cast<uint32_t>(logging.minimumLevel))
+	{
+		return;
+	}
+
+	logging.callback(level, message, logging.userData);
+}

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -2,7 +2,8 @@
 
 AssetSuite::Internal::RuntimeContext::RuntimeContext(const ContextDesc& desc)
 	: desc(desc)
-	, manager()
+	, state()
+	, manager(state)
 	, logging()
 {
 }

--- a/source/runtime/AssetSuiteRuntime.h
+++ b/source/runtime/AssetSuiteRuntime.h
@@ -3,6 +3,7 @@
 #include <AssetSuite/AssetSuite.h>
 
 #include "../common/AssetSuite.h"
+#include "AssetSuiteRuntimeState.h"
 
 namespace AssetSuite::Internal
 {
@@ -31,6 +32,7 @@ namespace AssetSuite::Internal
 		};
 
 		ContextDesc desc;
+		RuntimeState state;
 		Manager manager;
 		LoggingState logging;
 	};

--- a/source/runtime/AssetSuiteRuntime.h
+++ b/source/runtime/AssetSuiteRuntime.h
@@ -19,6 +19,12 @@ namespace AssetSuite::Internal
 		const ContextDesc& Descriptor() const noexcept;
 		Manager& LegacyManager() noexcept;
 		const Manager& LegacyManager() const noexcept;
+		RuntimeState::AllocatorPolicy& AllocatorPolicy() noexcept;
+		RuntimeState::Diagnostics& Diagnostics() noexcept;
+		const RuntimeState::Diagnostics& Diagnostics() const noexcept;
+		RuntimeState::FileLoader& FileLoader() noexcept;
+		RuntimeState::CodecRegistry& CodecRegistry() noexcept;
+		const RuntimeState::CodecRegistry& CodecRegistry() const noexcept;
 
 		void SetLoggingCallback(LoggingCallback callback, LogLevel minimumLevel, void* userData) noexcept;
 		void DispatchLogEvent(LogLevel level, const char* message) const;

--- a/source/runtime/AssetSuiteRuntime.h
+++ b/source/runtime/AssetSuiteRuntime.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <AssetSuite/AssetSuite.h>
+
+#include "../common/AssetSuite.h"
+
+namespace AssetSuite::Internal
+{
+	class RuntimeContext final
+	{
+	public:
+		explicit RuntimeContext(const ContextDesc& desc);
+		~RuntimeContext();
+
+		RuntimeContext(const RuntimeContext&) = delete;
+		RuntimeContext& operator=(const RuntimeContext&) = delete;
+
+		const ContextDesc& Descriptor() const noexcept;
+		Manager& LegacyManager() noexcept;
+		const Manager& LegacyManager() const noexcept;
+
+		void SetLoggingCallback(LoggingCallback callback, LogLevel minimumLevel, void* userData) noexcept;
+		void DispatchLogEvent(LogLevel level, const char* message) const;
+
+	private:
+		struct LoggingState
+		{
+			LoggingCallback callback = nullptr;
+			LogLevel minimumLevel = LogLevel::Info;
+			void* userData = nullptr;
+		};
+
+		ContextDesc desc;
+		Manager manager;
+		LoggingState logging;
+	};
+}

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -1,0 +1,24 @@
+#include "AssetSuiteRuntimeState.h"
+
+#include "../wavefront/ModelLoader.h"
+#include "../bmp/BmpDecoder.h"
+#include "../png/PngDecoder.h"
+#include "../ppm/PpmEncoder.h"
+#include "../bypass/BypassEncoder.h"
+
+AssetSuite::Internal::RuntimeState::RuntimeState()
+	: modelLoader(std::make_unique<ModelLoader>())
+	, bmpDecoder(std::make_unique<BmpDecoder>())
+	, pngDecoder(std::make_unique<PngDecoder>())
+	, ppmEncoder(std::make_unique<PpmEncoder>())
+	, bypassEncoder(std::make_unique<BypassEncoder>())
+	, imageDecoders()
+	, meshDecoders()
+{
+	imageDecoders[static_cast<size_t>(ImageDecoders::BMP)] = bmpDecoder.get();
+	imageDecoders[static_cast<size_t>(ImageDecoders::PNG)] = pngDecoder.get();
+
+	meshDecoders[static_cast<size_t>(MeshDecoders::WAVEFRONT)] = modelLoader.get();
+}
+
+AssetSuite::Internal::RuntimeState::~RuntimeState() = default;

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -6,19 +6,153 @@
 #include "../ppm/PpmEncoder.h"
 #include "../bypass/BypassEncoder.h"
 
+#include <fstream>
+#include <new>
+
 AssetSuite::Internal::RuntimeState::RuntimeState()
 	: modelLoader(std::make_unique<ModelLoader>())
 	, bmpDecoder(std::make_unique<BmpDecoder>())
 	, pngDecoder(std::make_unique<PngDecoder>())
 	, ppmEncoder(std::make_unique<PpmEncoder>())
 	, bypassEncoder(std::make_unique<BypassEncoder>())
-	, imageDecoders()
-	, meshDecoders()
 {
-	imageDecoders[static_cast<size_t>(ImageDecoders::BMP)] = bmpDecoder.get();
-	imageDecoders[static_cast<size_t>(ImageDecoders::PNG)] = pngDecoder.get();
+	codecRegistry.RegisterImageDecoder(ImageDecoders::BMP, *bmpDecoder);
+	codecRegistry.RegisterImageDecoder(ImageDecoders::PNG, *pngDecoder);
 
-	meshDecoders[static_cast<size_t>(MeshDecoders::WAVEFRONT)] = modelLoader.get();
+	codecRegistry.RegisterMeshDecoder(MeshDecoders::WAVEFRONT, *modelLoader);
 }
 
 AssetSuite::Internal::RuntimeState::~RuntimeState() = default;
+
+void* AssetSuite::Internal::RuntimeState::AllocatorPolicy::Allocate(size_t size, size_t alignment)
+{
+	if (allocate)
+	{
+		return allocate(size, alignment, userData);
+	}
+
+	return ::operator new(size);
+}
+
+void AssetSuite::Internal::RuntimeState::AllocatorPolicy::Free(void* memory) noexcept
+{
+	if (!memory)
+	{
+		return;
+	}
+
+	if (free)
+	{
+		free(memory, userData);
+		return;
+	}
+
+	::operator delete(memory);
+}
+
+void AssetSuite::Internal::RuntimeState::Diagnostics::Clear()
+{
+	entries.clear();
+}
+
+void AssetSuite::Internal::RuntimeState::Diagnostics::Add(ErrorCode code, const char* message)
+{
+	entries.push_back({ code, message ? message : "" });
+}
+
+const std::vector<AssetSuite::Internal::RuntimeState::Diagnostics::Entry>&
+AssetSuite::Internal::RuntimeState::Diagnostics::Entries() const noexcept
+{
+	return entries;
+}
+
+AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemory(
+	const std::filesystem::path& fileName,
+	bool isBinary,
+	std::vector<BYTE>& output) const
+{
+	if (!std::filesystem::exists(fileName))
+	{
+		return ErrorCode::NonExistingFile;
+	}
+
+	output.clear();
+
+	std::ifstream file(fileName.c_str(), std::ios::in | std::ios::ate | std::ios::binary);
+	std::streamsize size = 0;
+
+	if (file.seekg(0, std::ios::end).good())
+	{
+		size = file.tellg();
+	}
+
+	if (file.seekg(0, std::ios::beg).good())
+	{
+		size -= file.tellg();
+	}
+
+	if (size > 0)
+	{
+		output.resize(static_cast<size_t>(size));
+		file.read(reinterpret_cast<char*>(output.data()), size);
+		if (!isBinary)
+		{
+			output.push_back('\0');
+		}
+	}
+
+	return ErrorCode::OK;
+}
+
+void AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(
+	ImageDecoders decoder,
+	ImageDecoder& implementation) noexcept
+{
+	imageDecoders[static_cast<size_t>(decoder)] = &implementation;
+}
+
+void AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterMeshDecoder(
+	MeshDecoders decoder,
+	MeshDecoder& implementation) noexcept
+{
+	meshDecoders[static_cast<size_t>(decoder)] = &implementation;
+}
+
+AssetSuite::ImageDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageDecoder(
+	ImageDecoders decoder) const noexcept
+{
+	return imageDecoders[static_cast<size_t>(decoder)];
+}
+
+AssetSuite::MeshDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::FindMeshDecoder(
+	MeshDecoders decoder) const noexcept
+{
+	return meshDecoders[static_cast<size_t>(decoder)];
+}
+
+AssetSuite::ImageDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::ResolveImageDecoder(
+	const std::filesystem::path& extension) const noexcept
+{
+	if (extension.compare(".bmp") == 0)
+	{
+		return ImageDecoders::BMP;
+	}
+
+	if (extension.compare(".png") == 0)
+	{
+		return ImageDecoders::PNG;
+	}
+
+	return ImageDecoders::Auto;
+}
+
+AssetSuite::MeshDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::ResolveMeshDecoder(
+	const std::filesystem::path& extension) const noexcept
+{
+	if (extension.compare(".obj") == 0)
+	{
+		return MeshDecoders::WAVEFRONT;
+	}
+
+	return MeshDecoders::Auto;
+}

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -10,19 +10,30 @@
 #include <new>
 
 AssetSuite::Internal::RuntimeState::RuntimeState()
+	: codecs()
+{
+	codecs.RegisterWith(codecRegistry);
+}
+
+AssetSuite::Internal::RuntimeState::~RuntimeState() = default;
+
+AssetSuite::Internal::RuntimeState::CodecStorage::CodecStorage()
 	: modelLoader(std::make_unique<ModelLoader>())
 	, bmpDecoder(std::make_unique<BmpDecoder>())
 	, pngDecoder(std::make_unique<PngDecoder>())
 	, ppmEncoder(std::make_unique<PpmEncoder>())
 	, bypassEncoder(std::make_unique<BypassEncoder>())
 {
-	codecRegistry.RegisterImageDecoder(ImageDecoders::BMP, *bmpDecoder);
-	codecRegistry.RegisterImageDecoder(ImageDecoders::PNG, *pngDecoder);
-
-	codecRegistry.RegisterMeshDecoder(MeshDecoders::WAVEFRONT, *modelLoader);
 }
 
-AssetSuite::Internal::RuntimeState::~RuntimeState() = default;
+AssetSuite::Internal::RuntimeState::CodecStorage::~CodecStorage() = default;
+
+void AssetSuite::Internal::RuntimeState::CodecStorage::RegisterWith(CodecRegistry& registry) noexcept
+{
+	registry.RegisterImageDecoder(ImageDecoders::BMP, *bmpDecoder);
+	registry.RegisterImageDecoder(ImageDecoders::PNG, *pngDecoder);
+	registry.RegisterMeshDecoder(MeshDecoders::WAVEFRONT, *modelLoader);
+}
 
 void* AssetSuite::Internal::RuntimeState::AllocatorPolicy::Allocate(size_t size, size_t alignment)
 {
@@ -104,29 +115,51 @@ AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemo
 	return ErrorCode::OK;
 }
 
-void AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(
+bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(
 	ImageDecoders decoder,
 	ImageDecoder& implementation) noexcept
 {
+	if (decoder == ImageDecoders::Auto || decoder == ImageDecoders::MaxDecoders)
+	{
+		return false;
+	}
+
 	imageDecoders[static_cast<size_t>(decoder)] = &implementation;
+	return true;
 }
 
-void AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterMeshDecoder(
+bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterMeshDecoder(
 	MeshDecoders decoder,
 	MeshDecoder& implementation) noexcept
 {
+	if (decoder == MeshDecoders::Auto || decoder == MeshDecoders::MaxDecoders)
+	{
+		return false;
+	}
+
 	meshDecoders[static_cast<size_t>(decoder)] = &implementation;
+	return true;
 }
 
 AssetSuite::ImageDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageDecoder(
 	ImageDecoders decoder) const noexcept
 {
+	if (decoder == ImageDecoders::Auto || decoder == ImageDecoders::MaxDecoders)
+	{
+		return nullptr;
+	}
+
 	return imageDecoders[static_cast<size_t>(decoder)];
 }
 
 AssetSuite::MeshDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::FindMeshDecoder(
 	MeshDecoders decoder) const noexcept
 {
+	if (decoder == MeshDecoders::Auto || decoder == MeshDecoders::MaxDecoders)
+	{
+		return nullptr;
+	}
+
 	return meshDecoders[static_cast<size_t>(decoder)];
 }
 

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <array>
+#include <filesystem>
+#include <memory>
+#include <vector>
+#include <Windows.h>
+
+#include "../common/ImageDescriptor.h"
+#include "../common/ImageDecoder.h"
+#include "../common/MeshDecoder.h"
+#include "../common/AssetSuite.h"
+
+namespace AssetSuite
+{
+	class ModelLoader;
+	class BmpDecoder;
+	class PngDecoder;
+	class PpmEncoder;
+	class BypassEncoder;
+}
+
+namespace AssetSuite::Internal
+{
+	struct RuntimeState final
+	{
+		struct FileInfo
+		{
+			std::filesystem::path fullName;
+			std::filesystem::path extension;
+		};
+
+		struct ImageInfo
+		{
+			UINT width = 0;
+			UINT height = 0;
+			ImageFormat format = ImageFormat::Unknown;
+		};
+
+		struct MeshInfo
+		{
+			UINT numOfVertices = 0;
+			UINT numOfIndices = 0;
+		};
+
+		RuntimeState();
+		~RuntimeState();
+
+		RuntimeState(const RuntimeState&) = delete;
+		RuntimeState& operator=(const RuntimeState&) = delete;
+
+		FileInfo fileInfo;
+		ImageInfo imageInfo;
+		MeshInfo meshInfo;
+		std::vector<BYTE> rawBuffer;
+		std::vector<BYTE> decodedBuffer;
+		std::vector<BYTE> formattedBuffer;
+		std::unique_ptr<ModelLoader> modelLoader;
+		std::unique_ptr<BmpDecoder> bmpDecoder;
+		std::unique_ptr<PngDecoder> pngDecoder;
+		std::unique_ptr<PpmEncoder> ppmEncoder;
+		std::unique_ptr<BypassEncoder> bypassEncoder;
+		std::array<ImageDecoder*, static_cast<size_t>(ImageDecoders::MaxDecoders)> imageDecoders;
+		std::array<MeshDecoder*, static_cast<size_t>(MeshDecoders::MaxDecoders)> meshDecoders;
+	};
+}

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <string>
 #include <vector>
 #include <Windows.h>
 
@@ -24,6 +26,54 @@ namespace AssetSuite::Internal
 {
 	struct RuntimeState final
 	{
+		struct AllocatorPolicy
+		{
+			using AllocateCallback = void* (*)(size_t size, size_t alignment, void* userData);
+			using FreeCallback = void (*)(void* memory, void* userData);
+
+			AllocateCallback allocate = nullptr;
+			FreeCallback free = nullptr;
+			void* userData = nullptr;
+
+			void* Allocate(size_t size, size_t alignment);
+			void Free(void* memory) noexcept;
+		};
+
+		struct Diagnostics
+		{
+			struct Entry
+			{
+				ErrorCode code = ErrorCode::OK;
+				std::string message;
+			};
+
+			void Clear();
+			void Add(ErrorCode code, const char* message);
+			const std::vector<Entry>& Entries() const noexcept;
+
+		private:
+			std::vector<Entry> entries;
+		};
+
+		struct FileLoader
+		{
+			ErrorCode LoadToMemory(const std::filesystem::path& fileName, bool isBinary, std::vector<BYTE>& output) const;
+		};
+
+		struct CodecRegistry
+		{
+			void RegisterImageDecoder(ImageDecoders decoder, ImageDecoder& implementation) noexcept;
+			void RegisterMeshDecoder(MeshDecoders decoder, MeshDecoder& implementation) noexcept;
+			ImageDecoder* FindImageDecoder(ImageDecoders decoder) const noexcept;
+			MeshDecoder* FindMeshDecoder(MeshDecoders decoder) const noexcept;
+			ImageDecoders ResolveImageDecoder(const std::filesystem::path& extension) const noexcept;
+			MeshDecoders ResolveMeshDecoder(const std::filesystem::path& extension) const noexcept;
+
+		private:
+			std::array<ImageDecoder*, static_cast<size_t>(ImageDecoders::MaxDecoders)> imageDecoders = {};
+			std::array<MeshDecoder*, static_cast<size_t>(MeshDecoders::MaxDecoders)> meshDecoders = {};
+		};
+
 		struct FileInfo
 		{
 			std::filesystem::path fullName;
@@ -60,7 +110,9 @@ namespace AssetSuite::Internal
 		std::unique_ptr<PngDecoder> pngDecoder;
 		std::unique_ptr<PpmEncoder> ppmEncoder;
 		std::unique_ptr<BypassEncoder> bypassEncoder;
-		std::array<ImageDecoder*, static_cast<size_t>(ImageDecoders::MaxDecoders)> imageDecoders;
-		std::array<MeshDecoder*, static_cast<size_t>(MeshDecoders::MaxDecoders)> meshDecoders;
+		AllocatorPolicy allocatorPolicy;
+		Diagnostics diagnostics;
+		FileLoader fileLoader;
+		CodecRegistry codecRegistry;
 	};
 }

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -62,8 +62,8 @@ namespace AssetSuite::Internal
 
 		struct CodecRegistry
 		{
-			void RegisterImageDecoder(ImageDecoders decoder, ImageDecoder& implementation) noexcept;
-			void RegisterMeshDecoder(MeshDecoders decoder, MeshDecoder& implementation) noexcept;
+			bool RegisterImageDecoder(ImageDecoders decoder, ImageDecoder& implementation) noexcept;
+			bool RegisterMeshDecoder(MeshDecoders decoder, MeshDecoder& implementation) noexcept;
 			ImageDecoder* FindImageDecoder(ImageDecoders decoder) const noexcept;
 			MeshDecoder* FindMeshDecoder(MeshDecoders decoder) const noexcept;
 			ImageDecoders ResolveImageDecoder(const std::filesystem::path& extension) const noexcept;
@@ -72,6 +72,23 @@ namespace AssetSuite::Internal
 		private:
 			std::array<ImageDecoder*, static_cast<size_t>(ImageDecoders::MaxDecoders)> imageDecoders = {};
 			std::array<MeshDecoder*, static_cast<size_t>(MeshDecoders::MaxDecoders)> meshDecoders = {};
+		};
+
+		struct CodecStorage
+		{
+			CodecStorage();
+			~CodecStorage();
+
+			CodecStorage(const CodecStorage&) = delete;
+			CodecStorage& operator=(const CodecStorage&) = delete;
+
+			std::unique_ptr<ModelLoader> modelLoader;
+			std::unique_ptr<BmpDecoder> bmpDecoder;
+			std::unique_ptr<PngDecoder> pngDecoder;
+			std::unique_ptr<PpmEncoder> ppmEncoder;
+			std::unique_ptr<BypassEncoder> bypassEncoder;
+
+			void RegisterWith(CodecRegistry& registry) noexcept;
 		};
 
 		struct FileInfo
@@ -105,11 +122,7 @@ namespace AssetSuite::Internal
 		std::vector<BYTE> rawBuffer;
 		std::vector<BYTE> decodedBuffer;
 		std::vector<BYTE> formattedBuffer;
-		std::unique_ptr<ModelLoader> modelLoader;
-		std::unique_ptr<BmpDecoder> bmpDecoder;
-		std::unique_ptr<PngDecoder> pngDecoder;
-		std::unique_ptr<PpmEncoder> ppmEncoder;
-		std::unique_ptr<BypassEncoder> bypassEncoder;
+		CodecStorage codecs;
 		AllocatorPolicy allocatorPolicy;
 		Diagnostics diagnostics;
 		FileLoader fileLoader;

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -1,0 +1,7 @@
+# AssetSuite Runtime Internals
+
+## Codec Ownership
+
+`RuntimeState::CodecStorage` owns the concrete codec, encoder, and loader instances for one runtime context. `RuntimeState::CodecRegistry` is a non-owning lookup table over those instances and must not allocate codecs or store process-global mutable codec state.
+
+Only concrete codec identifiers may be registered or queried. Sentinel values such as `Auto` and `MaxDecoders` are resolved or rejected before lookup.

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -1,7 +1,44 @@
 # AssetSuite Runtime Internals
 
+## Runtime Ownership
+
+`AssetSuite::ContextHandle` points to the private `AssetSuiteContext_t` bridge in `source/common`. That bridge owns one `Internal::RuntimeContext`, and the runtime context owns the per-context runtime state used by the current SDK adapter layer.
+
+The runtime currently owns:
+
+- the normalized `ContextDesc`
+- logger callback state
+- allocator policy placeholders
+- diagnostics storage
+- file loading support
+- source file metadata
+- raw, decoded, and formatted buffers
+- transient image and mesh metadata
+- codec registry access
+- codec, encoder, and Wavefront loader instances
+
+Legacy `Manager` remains as a compatibility facade for existing tests and demo code. It is bound to `RuntimeState` instead of owning runtime buffers and codec objects directly.
+
 ## Codec Ownership
 
 `RuntimeState::CodecStorage` owns the concrete codec, encoder, and loader instances for one runtime context. `RuntimeState::CodecRegistry` is a non-owning lookup table over those instances and must not allocate codecs or store process-global mutable codec state.
 
 Only concrete codec identifiers may be registered or queried. Sentinel values such as `Auto` and `MaxDecoders` are resolved or rejected before lookup.
+
+## SDK Boundary
+
+Runtime headers under `source/runtime` are private implementation files. They must not be installed with the public SDK headers and must not be included from `include/AssetSuite`.
+
+The public SDK surface is guarded by `PublicHeaderCompile`, `PublicHeaderHygiene.ps1`, and `AssertPublicInstallSurface.ps1`. These checks reject private runtime names in public headers and verify that the installed include tree contains only `AssetSuite/*.h`.
+
+## Deferred Scope
+
+This runtime layer is intentionally foundational. The following work is deferred to later stories:
+
+- blob creation and lifetime ownership
+- image and mesh child-handle tracking
+- shared file loading APIs
+- codec probing and richer format detection
+- public diagnostics reporting
+- allocator hooks wired into all internal allocations
+- broader asset storage and cleanup policies

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -2,6 +2,7 @@
 #include <CppUnitTest.h>
 #include "../source/common/AssetSuite.h"
 #include "../source/common/AssetSuiteContext.h"
+#include "../source/runtime/AssetSuiteRuntime.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -83,14 +84,13 @@ namespace GeneralUnitTests
 
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(&desc, &context));
 
-			AssetSuite::RuntimeSmokeStatus status = {};
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(context, &status));
-			Assert::AreEqual(desc.structSize, status.descriptorStructSize);
-			Assert::AreEqual(desc.flags, status.descriptorFlags);
-			Assert::IsTrue(status.hasBmpDecoder);
-			Assert::IsTrue(status.hasPngDecoder);
-			Assert::IsTrue(status.hasWavefrontDecoder);
-			Assert::AreEqual(static_cast<uint32_t>(0), status.diagnosticsEntryCount);
+			const auto& runtime = context->Runtime();
+			Assert::AreEqual(desc.structSize, runtime.Descriptor().structSize);
+			Assert::AreEqual(desc.flags, runtime.Descriptor().flags);
+			Assert::IsNotNull(runtime.CodecRegistry().FindImageDecoder(AssetSuite::ImageDecoders::BMP));
+			Assert::IsNotNull(runtime.CodecRegistry().FindImageDecoder(AssetSuite::ImageDecoders::PNG));
+			Assert::IsNotNull(runtime.CodecRegistry().FindMeshDecoder(AssetSuite::MeshDecoders::WAVEFRONT));
+			Assert::AreEqual(static_cast<size_t>(0), runtime.Diagnostics().Entries().size());
 
 			DestroyContextForCleanup(context);
 		}
@@ -301,18 +301,13 @@ namespace GeneralUnitTests
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &firstContext));
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &secondContext));
 
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::AddRuntimeSmokeDiagnostic(firstContext));
+			firstContext->Runtime().Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "runtime smoke diagnostic");
 
-			AssetSuite::RuntimeSmokeStatus firstStatus = {};
-			AssetSuite::RuntimeSmokeStatus secondStatus = {};
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(firstContext, &firstStatus));
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(secondContext, &secondStatus));
-			Assert::AreEqual(static_cast<uint32_t>(1), firstStatus.diagnosticsEntryCount);
-			Assert::AreEqual(static_cast<uint32_t>(0), secondStatus.diagnosticsEntryCount);
+			Assert::AreEqual(static_cast<size_t>(1), firstContext->Runtime().Diagnostics().Entries().size());
+			Assert::AreEqual(static_cast<size_t>(0), secondContext->Runtime().Diagnostics().Entries().size());
 
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ClearRuntimeSmokeDiagnostics(firstContext));
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(firstContext, &firstStatus));
-			Assert::AreEqual(static_cast<uint32_t>(0), firstStatus.diagnosticsEntryCount);
+			firstContext->Runtime().Diagnostics().Clear();
+			Assert::AreEqual(static_cast<size_t>(0), firstContext->Runtime().Diagnostics().Entries().size());
 
 			DestroyContextForCleanup(secondContext);
 			DestroyContextForCleanup(firstContext);
@@ -323,14 +318,20 @@ namespace GeneralUnitTests
 			AssetSuite::ContextHandle context = nullptr;
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
 
-			AssetSuite::RuntimeSmokeStatus status = {};
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(context, &status));
+			auto& registry = context->Runtime().CodecRegistry();
+			AssetSuite::ImageDecoder* imageDecoder = registry.FindImageDecoder(AssetSuite::ImageDecoders::BMP);
+			AssetSuite::MeshDecoder* meshDecoder = registry.FindMeshDecoder(AssetSuite::MeshDecoders::WAVEFRONT);
 
-			Assert::IsTrue(status.hasBmpDecoder);
-			Assert::IsTrue(status.hasPngDecoder);
-			Assert::IsTrue(status.hasWavefrontDecoder);
-			Assert::IsTrue(status.rejectsImageSentinels);
-			Assert::IsTrue(status.rejectsMeshSentinels);
+			Assert::IsNotNull(imageDecoder);
+			Assert::IsNotNull(meshDecoder);
+			Assert::IsNull(registry.FindImageDecoder(AssetSuite::ImageDecoders::Auto));
+			Assert::IsNull(registry.FindImageDecoder(AssetSuite::ImageDecoders::MaxDecoders));
+			Assert::IsNull(registry.FindMeshDecoder(AssetSuite::MeshDecoders::Auto));
+			Assert::IsNull(registry.FindMeshDecoder(AssetSuite::MeshDecoders::MaxDecoders));
+			Assert::IsFalse(registry.RegisterImageDecoder(AssetSuite::ImageDecoders::Auto, *imageDecoder));
+			Assert::IsFalse(registry.RegisterImageDecoder(AssetSuite::ImageDecoders::MaxDecoders, *imageDecoder));
+			Assert::IsFalse(registry.RegisterMeshDecoder(AssetSuite::MeshDecoders::Auto, *meshDecoder));
+			Assert::IsFalse(registry.RegisterMeshDecoder(AssetSuite::MeshDecoders::MaxDecoders, *meshDecoder));
 
 			DestroyContextForCleanup(context);
 		}

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -76,6 +76,25 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(context);
 		}
 
+		TEST_METHOD(CreateContextInitializesRuntimeServices)
+		{
+			AssetSuite::ContextDesc desc = { sizeof(AssetSuite::ContextDesc), 0 };
+			AssetSuite::ContextHandle context = nullptr;
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(&desc, &context));
+
+			AssetSuite::RuntimeSmokeStatus status = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(context, &status));
+			Assert::AreEqual(desc.structSize, status.descriptorStructSize);
+			Assert::AreEqual(desc.flags, status.descriptorFlags);
+			Assert::IsTrue(status.hasBmpDecoder);
+			Assert::IsTrue(status.hasPngDecoder);
+			Assert::IsTrue(status.hasWavefrontDecoder);
+			Assert::AreEqual(static_cast<uint32_t>(0), status.diagnosticsEntryCount);
+
+			DestroyContextForCleanup(context);
+		}
+
 		TEST_METHOD(CreateContextRejectsNullOutput)
 		{
 			const auto result = AssetSuite::CreateContext(nullptr, nullptr);
@@ -271,6 +290,47 @@ namespace GeneralUnitTests
 			AssetSuite::DispatchLogEvent(context, AssetSuite::LogLevel::Fatal, "unregistered");
 
 			Assert::AreEqual(0, capture.callCount);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeDiagnosticsAreContextScoped)
+		{
+			AssetSuite::ContextHandle firstContext = nullptr;
+			AssetSuite::ContextHandle secondContext = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &firstContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &secondContext));
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::AddRuntimeSmokeDiagnostic(firstContext));
+
+			AssetSuite::RuntimeSmokeStatus firstStatus = {};
+			AssetSuite::RuntimeSmokeStatus secondStatus = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(firstContext, &firstStatus));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(secondContext, &secondStatus));
+			Assert::AreEqual(static_cast<uint32_t>(1), firstStatus.diagnosticsEntryCount);
+			Assert::AreEqual(static_cast<uint32_t>(0), secondStatus.diagnosticsEntryCount);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ClearRuntimeSmokeDiagnostics(firstContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(firstContext, &firstStatus));
+			Assert::AreEqual(static_cast<uint32_t>(0), firstStatus.diagnosticsEntryCount);
+
+			DestroyContextForCleanup(secondContext);
+			DestroyContextForCleanup(firstContext);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryRejectsSentinelSlots)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			AssetSuite::RuntimeSmokeStatus status = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CaptureRuntimeSmokeStatus(context, &status));
+
+			Assert::IsTrue(status.hasBmpDecoder);
+			Assert::IsTrue(status.hasPngDecoder);
+			Assert::IsTrue(status.hasWavefrontDecoder);
+			Assert::IsTrue(status.rejectsImageSentinels);
+			Assert::IsTrue(status.rejectsMeshSentinels);
 
 			DestroyContextForCleanup(context);
 		}

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -23,6 +23,13 @@
 #define MeshDecoder ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(MeshDecoder)
 #define ImageDecoders ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(ImageDecoders)
 #define MeshDecoders ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(MeshDecoders)
+#define RuntimeContext ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(RuntimeContext)
+#define RuntimeState ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(RuntimeState)
+#define CodecStorage ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(CodecStorage)
+#define CodecRegistry ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(CodecRegistry)
+#define AllocatorPolicy ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(AllocatorPolicy)
+#define Diagnostics ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(Diagnostics)
+#define FileLoader ASSETSUITE_FORBIDDEN_PUBLIC_SYMBOL(FileLoader)
 
 #include <AssetSuite/AssetSuite.h>
 #include <AssetSuite/AssetSuiteDescriptors.h>
@@ -51,6 +58,13 @@
 #undef MeshDecoder
 #undef ImageDecoders
 #undef MeshDecoders
+#undef RuntimeContext
+#undef RuntimeState
+#undef CodecStorage
+#undef CodecRegistry
+#undef AllocatorPolicy
+#undef Diagnostics
+#undef FileLoader
 
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::Result>, int32_t>);
 static_assert(std::is_same_v<std::underlying_type_t<AssetSuite::PixelFormat>, uint32_t>);

--- a/validation/public_header_hygiene/AssertPublicInstallSurface.ps1
+++ b/validation/public_header_hygiene/AssertPublicInstallSurface.ps1
@@ -17,11 +17,36 @@ if (-not (Test-Path -LiteralPath $rootPath)) {
 $resolvedRoot = (Resolve-Path -LiteralPath $rootPath).Path
 $violations = New-Object System.Collections.Generic.List[string]
 $headers = Get-ChildItem -LiteralPath $resolvedRoot -Recurse -File -Filter "*.h"
+$expectedHeaders = @(
+	"AssetSuite/AssetSuite.h",
+	"AssetSuite/AssetSuiteDescriptors.h",
+	"AssetSuite/AssetSuiteExport.h",
+	"AssetSuite/AssetSuiteHandles.h",
+	"AssetSuite/AssetSuiteTypes.h"
+)
+$seenHeaders = New-Object "System.Collections.Generic.HashSet[string]"
+
+if ($headers.Count -eq 0) {
+	$violations.Add("${resolvedRoot}: no installed public headers were found")
+}
 
 foreach ($header in $headers) {
-	$relativePath = $header.FullName.Substring($resolvedRoot.Length).TrimStart("\", "/")
+	$relativePath = $header.FullName.Substring($resolvedRoot.Length).TrimStart("\", "/").Replace("\", "/")
+	[void]$seenHeaders.Add($relativePath)
 	if ($relativePath -notmatch '^AssetSuite[\\/][^\\/]+\.h$') {
 		$violations.Add("${header}: installed header must live under AssetSuite/*.h")
+	}
+}
+
+foreach ($expectedHeader in $expectedHeaders) {
+	if (-not $seenHeaders.Contains($expectedHeader)) {
+		$violations.Add("${resolvedRoot}: missing expected public header $expectedHeader")
+	}
+}
+
+foreach ($seenHeader in $seenHeaders) {
+	if ($expectedHeaders -notcontains $seenHeader) {
+		$violations.Add("${resolvedRoot}: unexpected installed public header $seenHeader")
 	}
 }
 

--- a/validation/public_header_hygiene/AssertPublicInstallSurface.ps1
+++ b/validation/public_header_hygiene/AssertPublicInstallSurface.ps1
@@ -1,0 +1,36 @@
+param(
+	[string]$InstalledIncludeRoot = "bin/Debug/inc"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repositoryRoot = Resolve-Path (Join-Path $PSScriptRoot "../..")
+$rootPath = $InstalledIncludeRoot
+if (-not [System.IO.Path]::IsPathRooted($rootPath)) {
+	$rootPath = Join-Path $repositoryRoot $rootPath
+}
+
+if (-not (Test-Path -LiteralPath $rootPath)) {
+	Write-Error "Installed include root does not exist: $rootPath"
+}
+
+$resolvedRoot = (Resolve-Path -LiteralPath $rootPath).Path
+$violations = New-Object System.Collections.Generic.List[string]
+$headers = Get-ChildItem -LiteralPath $resolvedRoot -Recurse -File -Filter "*.h"
+
+foreach ($header in $headers) {
+	$relativePath = $header.FullName.Substring($resolvedRoot.Length).TrimStart("\", "/")
+	if ($relativePath -notmatch '^AssetSuite[\\/][^\\/]+\.h$') {
+		$violations.Add("${header}: installed header must live under AssetSuite/*.h")
+	}
+}
+
+if ($violations.Count -gt 0) {
+	Write-Host "Public install surface violations:"
+	foreach ($violation in $violations) {
+		Write-Host "  $violation"
+	}
+	exit 1
+}
+
+Write-Host "Public install surface check passed for $($headers.Count) headers."

--- a/validation/public_header_hygiene/PublicHeaderHygiene.ps1
+++ b/validation/public_header_hygiene/PublicHeaderHygiene.ps1
@@ -14,6 +14,7 @@ $patterns = [ordered]@{
 	"Win32 alias type" = '\b(?:BYTE|FLOAT|UINT)\b'
 	"STL owning API type" = '\bstd\s*::\s*(?:vector|string|basic_string)\b|\bstd\s*::\s*filesystem\s*::\s*path\b'
 	"Legacy manager or decoder surface" = '\b(?:Manager|Decoder|ImageDecoder|MeshDecoder|ImageDecoders|MeshDecoders)\b'
+	"Private runtime surface" = '\b(?:RuntimeContext|RuntimeState|CodecStorage|CodecRegistry|AllocatorPolicy|Diagnostics|FileLoader)\b'
 }
 
 $violations = New-Object System.Collections.Generic.List[string]


### PR DESCRIPTION
## Summary

Implements the private runtime foundation behind `ContextHandle` for issue #40.

This PR introduces an internal `RuntimeContext`, moves legacy runtime-owned state out of direct `Manager` ownership into `RuntimeState`, adds foundational runtime services for diagnostics, allocator policy, file loading, and codec registry access, and centralizes context lifecycle helpers.

It also protects the public SDK surface with stronger installed-header validation, adds runtime smoke coverage, and documents runtime ownership boundaries plus deferred scope.

Closes #40.

## Validation

- `git diff --check`
- Public header hygiene validation
- Public installed-header surface validation
- `AssetSuite.vcxproj` Debug build
- `UnitTest.vcxproj` Debug build
- `vstest.console.exe bin\Debug\tests\UnitTest.dll` passed: 136/136 tests

## Notes

`gh` is not available on PATH in this environment, so the branch was pushed with local `git` and the draft PR was opened through the GitHub connector.