### PR TITLE
[codex] Implement blob lifecycle storage

### DIFF
--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -45,6 +45,8 @@ namespace AssetSuite
 	// retains ownership of filePath and may release or mutate that string after
 	// the call returns. A returned blob remains valid until ReleaseBlob is
 	// called for the same context, or until the owning context is destroyed.
+	// Blob operations follow the context's external synchronization
+	// requirements.
 	//
 	// Passing a null context returns Result::ErrorInvalidContext. Passing a
 	// null filePath, null outBlob, or non-null *outBlob returns
@@ -59,6 +61,7 @@ namespace AssetSuite
 	// The blob must have been created by LoadFile on the same context. Passing
 	// a null context returns Result::ErrorInvalidContext. Passing nullptr, a
 	// pointer to a null blob handle, a stale handle, or a handle from another
-	// context returns Result::ErrorInvalidHandle.
+	// context returns Result::ErrorInvalidHandle. On failure, the caller's blob
+	// value is preserved.
 	ASSET_SUITE_API Result ReleaseBlob(ContextHandle context, BlobHandle* blob);
 }

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -37,4 +37,28 @@ namespace AssetSuite
 		LoggingCallback callback,
 		LogLevel minLevel,
 		void* userData);
+
+	// Loads a file into a runtime-owned blob. outBlob must point to a null
+	// handle and receives ownership of the created blob handle on success.
+	//
+	// The blob bytes and source metadata are owned by the context. The caller
+	// retains ownership of filePath and may release or mutate that string after
+	// the call returns. A returned blob remains valid until ReleaseBlob is
+	// called for the same context, or until the owning context is destroyed.
+	//
+	// Passing a null context returns Result::ErrorInvalidContext. Passing a
+	// null filePath, null outBlob, or non-null *outBlob returns
+	// Result::ErrorInvalidArgument. Missing files return
+	// Result::ErrorFileNotFound.
+	ASSET_SUITE_API Result LoadFile(ContextHandle context, const char* filePath, BlobHandle* outBlob);
+
+	// Releases a runtime-owned blob and sets the caller's handle to nullptr on
+	// success. Memory and metadata behind the blob are invalid immediately
+	// after a successful release.
+	//
+	// The blob must have been created by LoadFile on the same context. Passing
+	// a null context returns Result::ErrorInvalidContext. Passing nullptr, a
+	// pointer to a null blob handle, a stale handle, or a handle from another
+	// context returns Result::ErrorInvalidHandle.
+	ASSET_SUITE_API Result ReleaseBlob(ContextHandle context, BlobHandle* blob);
 }

--- a/include/AssetSuite/AssetSuiteDescriptors.h
+++ b/include/AssetSuite/AssetSuiteDescriptors.h
@@ -16,9 +16,14 @@ namespace AssetSuite
 
 	struct BlobDesc
 	{
+		// Must be exactly sizeof(BlobDesc) when a descriptor is supplied.
 		uint32_t structSize;
+		// Number of bytes owned by the blob.
 		uint64_t byteSize;
+		// Best-known asset format. May be Unknown when the source extension or
+		// signature does not identify a supported asset type.
 		AssetFormat format;
+		// Reserved for future use. Must be zero.
 		uint32_t flags;
 	};
 

--- a/include/AssetSuite/AssetSuiteTypes.h
+++ b/include/AssetSuite/AssetSuiteTypes.h
@@ -18,6 +18,7 @@ namespace AssetSuite
 		ErrorOutputBufferTooSmall = -5,
 		ErrorOutOfMemory = -6,
 		ErrorInvalidContext = -7,
+		ErrorInvalidHandle = -8,
 		ErrorUnknown = -1000
 	};
 

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -152,7 +152,7 @@ AssetSuite::Result AssetSuite::LoadFile(ContextHandle context, const char* fileP
 		return Result::ErrorInvalidArgument;
 	}
 
-	std::vector<BYTE> rawBytes;
+	std::vector<uint8_t> rawBytes;
 	const ErrorCode loadResult = context->Runtime().FileLoader().LoadToMemory(filePath, true, rawBytes);
 	const Result mappedResult = MapFileLoadResult(loadResult);
 	if (mappedResult != Result::Success)
@@ -163,8 +163,7 @@ AssetSuite::Result AssetSuite::LoadFile(ContextHandle context, const char* fileP
 
 	try
 	{
-		std::vector<uint8_t> bytes(rawBytes.begin(), rawBytes.end());
-		Internal::Blob blob(std::move(bytes), Internal::MakeBlobSourceMetadata(filePath));
+		Internal::Blob blob(std::move(rawBytes), Internal::MakeBlobSourceMetadata(filePath));
 		*outBlob = context->Runtime().BlobStorage().Create(std::move(blob));
 	}
 	catch (const std::bad_alloc&)

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -41,6 +41,19 @@ namespace
 		normalizedDesc = *desc;
 		return AssetSuite::Result::Success;
 	}
+
+	AssetSuite::Result MapFileLoadResult(AssetSuite::ErrorCode error)
+	{
+		switch (error)
+		{
+		case AssetSuite::ErrorCode::OK:
+			return AssetSuite::Result::Success;
+		case AssetSuite::ErrorCode::NonExistingFile:
+			return AssetSuite::Result::ErrorFileNotFound;
+		default:
+			return AssetSuite::Result::ErrorUnknown;
+		}
+	}
 }
 
 AssetSuite::Result AssetSuite::GetVersion(Version* outVersion)
@@ -139,7 +152,31 @@ AssetSuite::Result AssetSuite::LoadFile(ContextHandle context, const char* fileP
 		return Result::ErrorInvalidArgument;
 	}
 
-	return Result::ErrorUnknown;
+	std::vector<BYTE> rawBytes;
+	const ErrorCode loadResult = context->Runtime().FileLoader().LoadToMemory(filePath, true, rawBytes);
+	const Result mappedResult = MapFileLoadResult(loadResult);
+	if (mappedResult != Result::Success)
+	{
+		context->Runtime().Diagnostics().Add(loadResult, "Failed to load blob source file.");
+		return mappedResult;
+	}
+
+	try
+	{
+		std::vector<uint8_t> bytes(rawBytes.begin(), rawBytes.end());
+		Internal::Blob blob(std::move(bytes), Internal::MakeBlobSourceMetadata(filePath));
+		*outBlob = context->Runtime().BlobStorage().Create(std::move(blob));
+	}
+	catch (const std::bad_alloc&)
+	{
+		return Result::ErrorOutOfMemory;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
+	}
+
+	return Result::Success;
 }
 
 AssetSuite::Result AssetSuite::ReleaseBlob(ContextHandle context, BlobHandle* blob)

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -76,6 +76,8 @@ const char* AssetSuite::GetResultString(Result result)
 		return "Error: out of memory";
 	case Result::ErrorInvalidContext:
 		return "Error: invalid context";
+	case Result::ErrorInvalidHandle:
+		return "Error: invalid handle";
 	case Result::ErrorUnknown:
 		return "Error: unknown";
 	default:
@@ -123,6 +125,36 @@ AssetSuite::Result AssetSuite::SetLoggingCallback(
 
 	context->Runtime().SetLoggingCallback(callback, minLevel, userData);
 	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::LoadFile(ContextHandle context, const char* filePath, BlobHandle* outBlob)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!filePath || !outBlob || *outBlob)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	return Result::ErrorUnknown;
+}
+
+AssetSuite::Result AssetSuite::ReleaseBlob(ContextHandle context, BlobHandle* blob)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!blob || !*blob)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	return Result::ErrorUnknown;
 }
 
 AssetSuite::Manager::Manager()

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -191,7 +191,7 @@ AssetSuite::Result AssetSuite::ReleaseBlob(ContextHandle context, BlobHandle* bl
 		return Result::ErrorInvalidHandle;
 	}
 
-	return Result::ErrorUnknown;
+	return context->Runtime().BlobStorage().Release(blob);
 }
 
 AssetSuite::Manager::Manager()

--- a/source/runtime/AssetSuiteBlob.cpp
+++ b/source/runtime/AssetSuiteBlob.cpp
@@ -1,27 +1,40 @@
 #include "AssetSuiteBlob.h"
 
+#include <algorithm>
+#include <cctype>
+#include <string>
 #include <utility>
 
 namespace
 {
 	AssetSuite::AssetFormat ResolveBlobFormat(const std::filesystem::path& extension) noexcept
 	{
-		if (extension == ".bmp")
+		std::string normalizedExtension = extension.string();
+		std::transform(
+			normalizedExtension.begin(),
+			normalizedExtension.end(),
+			normalizedExtension.begin(),
+			[](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+
+		if (normalizedExtension == ".bmp")
 		{
 			return AssetSuite::AssetFormat::BMP;
 		}
 
-		if (extension == ".png")
+		if (normalizedExtension == ".png")
 		{
 			return AssetSuite::AssetFormat::PNG;
 		}
 
-		if (extension == ".ppm")
+		if (normalizedExtension == ".ppm")
 		{
 			return AssetSuite::AssetFormat::PPM;
 		}
 
-		if (extension == ".obj")
+		if (normalizedExtension == ".obj")
 		{
 			return AssetSuite::AssetFormat::WavefrontObj;
 		}
@@ -75,31 +88,4 @@ AssetSuite::Internal::MakeBlobSourceMetadata(const std::filesystem::path& source
 	metadata.extension = sourcePath.extension();
 	metadata.format = ResolveBlobFormat(metadata.extension);
 	return metadata;
-}
-
-AssetSuite::AssetSuiteBlob_t::AssetSuiteBlob_t(Internal::Blob blob)
-	: blob(std::make_unique<Internal::Blob>(std::move(blob)))
-{
-}
-
-AssetSuite::AssetSuiteBlob_t::~AssetSuiteBlob_t() = default;
-
-AssetSuite::Internal::Blob& AssetSuite::AssetSuiteBlob_t::Blob() noexcept
-{
-	return *blob;
-}
-
-const AssetSuite::Internal::Blob& AssetSuite::AssetSuiteBlob_t::Blob() const noexcept
-{
-	return *blob;
-}
-
-bool AssetSuite::AssetSuiteBlob_t::IsLive() const noexcept
-{
-	return blob != nullptr;
-}
-
-void AssetSuite::AssetSuiteBlob_t::Release() noexcept
-{
-	blob.reset();
 }

--- a/source/runtime/AssetSuiteBlob.cpp
+++ b/source/runtime/AssetSuiteBlob.cpp
@@ -93,3 +93,13 @@ const AssetSuite::Internal::Blob& AssetSuite::AssetSuiteBlob_t::Blob() const noe
 {
 	return *blob;
 }
+
+bool AssetSuite::AssetSuiteBlob_t::IsLive() const noexcept
+{
+	return blob != nullptr;
+}
+
+void AssetSuite::AssetSuiteBlob_t::Release() noexcept
+{
+	blob.reset();
+}

--- a/source/runtime/AssetSuiteBlob.cpp
+++ b/source/runtime/AssetSuiteBlob.cpp
@@ -1,0 +1,95 @@
+#include "AssetSuiteBlob.h"
+
+#include <utility>
+
+namespace
+{
+	AssetSuite::AssetFormat ResolveBlobFormat(const std::filesystem::path& extension) noexcept
+	{
+		if (extension == ".bmp")
+		{
+			return AssetSuite::AssetFormat::BMP;
+		}
+
+		if (extension == ".png")
+		{
+			return AssetSuite::AssetFormat::PNG;
+		}
+
+		if (extension == ".ppm")
+		{
+			return AssetSuite::AssetFormat::PPM;
+		}
+
+		if (extension == ".obj")
+		{
+			return AssetSuite::AssetFormat::WavefrontObj;
+		}
+
+		return AssetSuite::AssetFormat::Unknown;
+	}
+}
+
+AssetSuite::Internal::Blob::Blob(std::vector<uint8_t> bytes, BlobSourceMetadata metadata)
+	: bytes(std::move(bytes))
+	, metadata(std::move(metadata))
+{
+}
+
+AssetSuite::Internal::Blob::Blob(Blob&&) noexcept = default;
+
+AssetSuite::Internal::Blob& AssetSuite::Internal::Blob::operator=(Blob&&) noexcept = default;
+
+const uint8_t* AssetSuite::Internal::Blob::Data() const noexcept
+{
+	return bytes.empty() ? nullptr : bytes.data();
+}
+
+uint64_t AssetSuite::Internal::Blob::ByteSize() const noexcept
+{
+	return static_cast<uint64_t>(bytes.size());
+}
+
+const AssetSuite::Internal::BlobSourceMetadata&
+AssetSuite::Internal::Blob::SourceMetadata() const noexcept
+{
+	return metadata;
+}
+
+AssetSuite::BlobDesc AssetSuite::Internal::Blob::Describe() const noexcept
+{
+	return BlobDesc
+	{
+		sizeof(BlobDesc),
+		ByteSize(),
+		metadata.format,
+		0
+	};
+}
+
+AssetSuite::Internal::BlobSourceMetadata
+AssetSuite::Internal::MakeBlobSourceMetadata(const std::filesystem::path& sourcePath)
+{
+	BlobSourceMetadata metadata = {};
+	metadata.sourcePath = sourcePath;
+	metadata.extension = sourcePath.extension();
+	metadata.format = ResolveBlobFormat(metadata.extension);
+	return metadata;
+}
+
+AssetSuite::AssetSuiteBlob_t::AssetSuiteBlob_t(Internal::Blob blob)
+	: blob(std::make_unique<Internal::Blob>(std::move(blob)))
+{
+}
+
+AssetSuite::AssetSuiteBlob_t::~AssetSuiteBlob_t() = default;
+
+AssetSuite::Internal::Blob& AssetSuite::AssetSuiteBlob_t::Blob() noexcept
+{
+	return *blob;
+}
+
+const AssetSuite::Internal::Blob& AssetSuite::AssetSuiteBlob_t::Blob() const noexcept
+{
+	return *blob;
+}

--- a/source/runtime/AssetSuiteBlob.h
+++ b/source/runtime/AssetSuiteBlob.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <filesystem>
-#include <memory>
 #include <vector>
 
 namespace AssetSuite::Internal
@@ -45,18 +44,5 @@ namespace AssetSuite
 {
 	struct AssetSuiteBlob_t
 	{
-		explicit AssetSuiteBlob_t(Internal::Blob blob);
-		~AssetSuiteBlob_t();
-
-		AssetSuiteBlob_t(const AssetSuiteBlob_t&) = delete;
-		AssetSuiteBlob_t& operator=(const AssetSuiteBlob_t&) = delete;
-
-		Internal::Blob& Blob() noexcept;
-		const Internal::Blob& Blob() const noexcept;
-		bool IsLive() const noexcept;
-		void Release() noexcept;
-
-	private:
-		std::unique_ptr<Internal::Blob> blob;
 	};
 }

--- a/source/runtime/AssetSuiteBlob.h
+++ b/source/runtime/AssetSuiteBlob.h
@@ -53,6 +53,8 @@ namespace AssetSuite
 
 		Internal::Blob& Blob() noexcept;
 		const Internal::Blob& Blob() const noexcept;
+		bool IsLive() const noexcept;
+		void Release() noexcept;
 
 	private:
 		std::unique_ptr<Internal::Blob> blob;

--- a/source/runtime/AssetSuiteBlob.h
+++ b/source/runtime/AssetSuiteBlob.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <AssetSuite/AssetSuiteDescriptors.h>
+#include <AssetSuite/AssetSuiteHandles.h>
+#include <AssetSuite/AssetSuiteTypes.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+namespace AssetSuite::Internal
+{
+	struct BlobSourceMetadata final
+	{
+		std::filesystem::path sourcePath;
+		std::filesystem::path extension;
+		AssetFormat format = AssetFormat::Unknown;
+	};
+
+	class Blob final
+	{
+	public:
+		Blob(std::vector<uint8_t> bytes, BlobSourceMetadata metadata);
+
+		Blob(const Blob&) = delete;
+		Blob& operator=(const Blob&) = delete;
+		Blob(Blob&&) noexcept;
+		Blob& operator=(Blob&&) noexcept;
+
+		const uint8_t* Data() const noexcept;
+		uint64_t ByteSize() const noexcept;
+		const BlobSourceMetadata& SourceMetadata() const noexcept;
+		BlobDesc Describe() const noexcept;
+
+	private:
+		std::vector<uint8_t> bytes;
+		BlobSourceMetadata metadata;
+	};
+
+	BlobSourceMetadata MakeBlobSourceMetadata(const std::filesystem::path& sourcePath);
+}
+
+namespace AssetSuite
+{
+	struct AssetSuiteBlob_t
+	{
+		explicit AssetSuiteBlob_t(Internal::Blob blob);
+		~AssetSuiteBlob_t();
+
+		AssetSuiteBlob_t(const AssetSuiteBlob_t&) = delete;
+		AssetSuiteBlob_t& operator=(const AssetSuiteBlob_t&) = delete;
+
+		Internal::Blob& Blob() noexcept;
+		const Internal::Blob& Blob() const noexcept;
+
+	private:
+		std::unique_ptr<Internal::Blob> blob;
+	};
+}

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -49,6 +49,18 @@ AssetSuite::Internal::RuntimeContext::FileLoader() noexcept
 	return state.fileLoader;
 }
 
+AssetSuite::Internal::RuntimeState::BlobStorage&
+AssetSuite::Internal::RuntimeContext::BlobStorage() noexcept
+{
+	return state.blobStorage;
+}
+
+const AssetSuite::Internal::RuntimeState::BlobStorage&
+AssetSuite::Internal::RuntimeContext::BlobStorage() const noexcept
+{
+	return state.blobStorage;
+}
+
 AssetSuite::Internal::RuntimeState::CodecRegistry&
 AssetSuite::Internal::RuntimeContext::CodecRegistry() noexcept
 {

--- a/source/runtime/AssetSuiteRuntime.h
+++ b/source/runtime/AssetSuiteRuntime.h
@@ -23,6 +23,8 @@ namespace AssetSuite::Internal
 		RuntimeState::Diagnostics& Diagnostics() noexcept;
 		const RuntimeState::Diagnostics& Diagnostics() const noexcept;
 		RuntimeState::FileLoader& FileLoader() noexcept;
+		RuntimeState::BlobStorage& BlobStorage() noexcept;
+		const RuntimeState::BlobStorage& BlobStorage() const noexcept;
 		RuntimeState::CodecRegistry& CodecRegistry() noexcept;
 		const RuntimeState::CodecRegistry& CodecRegistry() const noexcept;
 

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -8,6 +8,7 @@
 
 #include <fstream>
 #include <new>
+#include <utility>
 
 AssetSuite::Internal::RuntimeState::RuntimeState()
 	: codecs()
@@ -113,6 +114,58 @@ AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemo
 	}
 
 	return ErrorCode::OK;
+}
+
+AssetSuite::BlobHandle AssetSuite::Internal::RuntimeState::BlobStorage::Create(Blob blob)
+{
+	auto storedBlob = std::make_unique<AssetSuiteBlob_t>(std::move(blob));
+	BlobHandle handle = storedBlob.get();
+	blobs.push_back(std::move(storedBlob));
+	return handle;
+}
+
+bool AssetSuite::Internal::RuntimeState::BlobStorage::Owns(BlobHandle blob) const noexcept
+{
+	for (const auto& storedBlob : blobs)
+	{
+		if (storedBlob.get() == blob)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool AssetSuite::Internal::RuntimeState::BlobStorage::IsLive(BlobHandle blob) const noexcept
+{
+	return Owns(blob) && blob->IsLive();
+}
+
+AssetSuite::Result AssetSuite::Internal::RuntimeState::BlobStorage::Release(BlobHandle* blob) noexcept
+{
+	if (!blob || !*blob || !IsLive(*blob))
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	(*blob)->Release();
+	*blob = nullptr;
+	return Result::Success;
+}
+
+size_t AssetSuite::Internal::RuntimeState::BlobStorage::LiveCount() const noexcept
+{
+	size_t count = 0;
+	for (const auto& storedBlob : blobs)
+	{
+		if (storedBlob->IsLive())
+		{
+			++count;
+		}
+	}
+
+	return count;
 }
 
 bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -8,23 +8,44 @@
 
 #include <fstream>
 #include <new>
+#include <atomic>
 #include <cstdint>
 #include <utility>
 
 namespace
 {
-	constexpr uintptr_t SLOT_INDEX_MASK = 0xffffffffu;
-	constexpr uint32_t INITIAL_BLOB_GENERATION = 1;
+	static_assert(sizeof(uintptr_t) >= 8, "BlobHandle token encoding requires a 64-bit target.");
 
-	AssetSuite::BlobHandle EncodeBlobHandle(size_t slotIndex, uint32_t generation) noexcept
+	constexpr uint32_t SLOT_INDEX_BITS = 24;
+	constexpr uint32_t GENERATION_BITS = 20;
+	constexpr uint32_t CONTEXT_ID_BITS = 20;
+	constexpr uintptr_t SLOT_INDEX_MASK = (uintptr_t{ 1 } << SLOT_INDEX_BITS) - 1u;
+	constexpr uintptr_t GENERATION_MASK = (uintptr_t{ 1 } << GENERATION_BITS) - 1u;
+	constexpr uintptr_t CONTEXT_ID_MASK = (uintptr_t{ 1 } << CONTEXT_ID_BITS) - 1u;
+	constexpr uint32_t INITIAL_BLOB_GENERATION = 1;
+	constexpr uint32_t INITIAL_BLOB_CONTEXT_ID = 1;
+
+	std::atomic<uint32_t> nextBlobContextId = INITIAL_BLOB_CONTEXT_ID;
+
+	AssetSuite::BlobHandle EncodeBlobHandle(size_t slotIndex, uint32_t generation, uint32_t contextId) noexcept
 	{
+		if (slotIndex >= SLOT_INDEX_MASK || generation == 0 || contextId == 0)
+		{
+			return nullptr;
+		}
+
 		const uintptr_t token =
-			(static_cast<uintptr_t>(generation) << 32) |
+			(static_cast<uintptr_t>(contextId) << (SLOT_INDEX_BITS + GENERATION_BITS)) |
+			(static_cast<uintptr_t>(generation) << SLOT_INDEX_BITS) |
 			(static_cast<uintptr_t>(slotIndex) + 1u);
 		return reinterpret_cast<AssetSuite::BlobHandle>(token);
 	}
 
-	bool DecodeBlobHandle(AssetSuite::BlobHandle handle, size_t& slotIndex, uint32_t& generation) noexcept
+	bool DecodeBlobHandle(
+		AssetSuite::BlobHandle handle,
+		size_t& slotIndex,
+		uint32_t& generation,
+		uint32_t& contextId) noexcept
 	{
 		const uintptr_t token = reinterpret_cast<uintptr_t>(handle);
 		const uintptr_t encodedSlotIndex = token & SLOT_INDEX_MASK;
@@ -33,8 +54,9 @@ namespace
 			return false;
 		}
 
-		generation = static_cast<uint32_t>(token >> 32);
-		if (generation == 0)
+		generation = static_cast<uint32_t>((token >> SLOT_INDEX_BITS) & GENERATION_MASK);
+		contextId = static_cast<uint32_t>((token >> (SLOT_INDEX_BITS + GENERATION_BITS)) & CONTEXT_ID_MASK);
+		if (generation == 0 || contextId == 0)
 		{
 			return false;
 		}
@@ -43,9 +65,15 @@ namespace
 		return true;
 	}
 
+	uint32_t AllocateBlobContextId() noexcept
+	{
+		uint32_t contextId = nextBlobContextId.fetch_add(1, std::memory_order_relaxed) & static_cast<uint32_t>(CONTEXT_ID_MASK);
+		return contextId == 0 ? INITIAL_BLOB_CONTEXT_ID : contextId;
+	}
+
 	uint32_t NextBlobGeneration(uint32_t generation) noexcept
 	{
-		++generation;
+		generation = (generation + 1u) & static_cast<uint32_t>(GENERATION_MASK);
 		return generation == 0 ? INITIAL_BLOB_GENERATION : generation;
 	}
 }
@@ -156,6 +184,11 @@ AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemo
 	return ErrorCode::OK;
 }
 
+AssetSuite::Internal::RuntimeState::BlobStorage::BlobStorage()
+	: contextId(AllocateBlobContextId())
+{
+}
+
 AssetSuite::BlobHandle AssetSuite::Internal::RuntimeState::BlobStorage::Create(Blob blob)
 {
 	size_t slotIndex = 0;
@@ -171,7 +204,7 @@ AssetSuite::BlobHandle AssetSuite::Internal::RuntimeState::BlobStorage::Create(B
 	}
 
 	slots[slotIndex].blob = std::make_unique<Blob>(std::move(blob));
-	return EncodeBlobHandle(slotIndex, slots[slotIndex].generation);
+	return EncodeBlobHandle(slotIndex, slots[slotIndex].generation, contextId);
 }
 
 bool AssetSuite::Internal::RuntimeState::BlobStorage::Owns(BlobHandle blob) const noexcept
@@ -189,7 +222,13 @@ AssetSuite::Internal::RuntimeState::BlobStorage::Get(BlobHandle blob) const noex
 {
 	size_t slotIndex = 0;
 	uint32_t generation = 0;
-	if (!DecodeBlobHandle(blob, slotIndex, generation))
+	uint32_t decodedContextId = 0;
+	if (!DecodeBlobHandle(blob, slotIndex, generation, decodedContextId))
+	{
+		return nullptr;
+	}
+
+	if (decodedContextId != contextId)
 	{
 		return nullptr;
 	}
@@ -212,7 +251,13 @@ AssetSuite::Result AssetSuite::Internal::RuntimeState::BlobStorage::Release(Blob
 {
 	size_t slotIndex = 0;
 	uint32_t generation = 0;
-	if (!blob || !DecodeBlobHandle(*blob, slotIndex, generation))
+	uint32_t decodedContextId = 0;
+	if (!blob || !DecodeBlobHandle(*blob, slotIndex, generation, decodedContextId))
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	if (decodedContextId != contextId)
 	{
 		return Result::ErrorInvalidHandle;
 	}

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -8,7 +8,47 @@
 
 #include <fstream>
 #include <new>
+#include <cstdint>
 #include <utility>
+
+namespace
+{
+	constexpr uintptr_t SLOT_INDEX_MASK = 0xffffffffu;
+	constexpr uint32_t INITIAL_BLOB_GENERATION = 1;
+
+	AssetSuite::BlobHandle EncodeBlobHandle(size_t slotIndex, uint32_t generation) noexcept
+	{
+		const uintptr_t token =
+			(static_cast<uintptr_t>(generation) << 32) |
+			(static_cast<uintptr_t>(slotIndex) + 1u);
+		return reinterpret_cast<AssetSuite::BlobHandle>(token);
+	}
+
+	bool DecodeBlobHandle(AssetSuite::BlobHandle handle, size_t& slotIndex, uint32_t& generation) noexcept
+	{
+		const uintptr_t token = reinterpret_cast<uintptr_t>(handle);
+		const uintptr_t encodedSlotIndex = token & SLOT_INDEX_MASK;
+		if (encodedSlotIndex == 0)
+		{
+			return false;
+		}
+
+		generation = static_cast<uint32_t>(token >> 32);
+		if (generation == 0)
+		{
+			return false;
+		}
+
+		slotIndex = static_cast<size_t>(encodedSlotIndex - 1u);
+		return true;
+	}
+
+	uint32_t NextBlobGeneration(uint32_t generation) noexcept
+	{
+		++generation;
+		return generation == 0 ? INITIAL_BLOB_GENERATION : generation;
+	}
+}
 
 AssetSuite::Internal::RuntimeState::RuntimeState()
 	: codecs()
@@ -81,7 +121,7 @@ AssetSuite::Internal::RuntimeState::Diagnostics::Entries() const noexcept
 AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemory(
 	const std::filesystem::path& fileName,
 	bool isBinary,
-	std::vector<BYTE>& output) const
+	std::vector<uint8_t>& output) const
 {
 	if (!std::filesystem::exists(fileName))
 	{
@@ -118,38 +158,79 @@ AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemo
 
 AssetSuite::BlobHandle AssetSuite::Internal::RuntimeState::BlobStorage::Create(Blob blob)
 {
-	auto storedBlob = std::make_unique<AssetSuiteBlob_t>(std::move(blob));
-	BlobHandle handle = storedBlob.get();
-	blobs.push_back(std::move(storedBlob));
-	return handle;
+	size_t slotIndex = 0;
+	if (!freeSlots.empty())
+	{
+		slotIndex = freeSlots.back();
+		freeSlots.pop_back();
+	}
+	else
+	{
+		slotIndex = slots.size();
+		slots.push_back({ nullptr, INITIAL_BLOB_GENERATION });
+	}
+
+	slots[slotIndex].blob = std::make_unique<Blob>(std::move(blob));
+	return EncodeBlobHandle(slotIndex, slots[slotIndex].generation);
 }
 
 bool AssetSuite::Internal::RuntimeState::BlobStorage::Owns(BlobHandle blob) const noexcept
 {
-	for (const auto& storedBlob : blobs)
-	{
-		if (storedBlob.get() == blob)
-		{
-			return true;
-		}
-	}
-
-	return false;
+	return Get(blob) != nullptr;
 }
 
 bool AssetSuite::Internal::RuntimeState::BlobStorage::IsLive(BlobHandle blob) const noexcept
 {
-	return Owns(blob) && blob->IsLive();
+	return Get(blob) != nullptr;
+}
+
+const AssetSuite::Internal::Blob*
+AssetSuite::Internal::RuntimeState::BlobStorage::Get(BlobHandle blob) const noexcept
+{
+	size_t slotIndex = 0;
+	uint32_t generation = 0;
+	if (!DecodeBlobHandle(blob, slotIndex, generation))
+	{
+		return nullptr;
+	}
+
+	if (slotIndex >= slots.size())
+	{
+		return nullptr;
+	}
+
+	const Slot& slot = slots[slotIndex];
+	if (slot.generation != generation || !slot.blob)
+	{
+		return nullptr;
+	}
+
+	return slot.blob.get();
 }
 
 AssetSuite::Result AssetSuite::Internal::RuntimeState::BlobStorage::Release(BlobHandle* blob) noexcept
 {
-	if (!blob || !*blob || !IsLive(*blob))
+	size_t slotIndex = 0;
+	uint32_t generation = 0;
+	if (!blob || !DecodeBlobHandle(*blob, slotIndex, generation))
 	{
 		return Result::ErrorInvalidHandle;
 	}
 
-	(*blob)->Release();
+	if (slotIndex >= slots.size())
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	Slot& slot = slots[slotIndex];
+	if (slot.generation != generation || !slot.blob)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	slot.blob.reset();
+	slot.generation = NextBlobGeneration(slot.generation);
+	freeSlots.push_back(slotIndex);
 	*blob = nullptr;
 	return Result::Success;
 }
@@ -157,15 +238,20 @@ AssetSuite::Result AssetSuite::Internal::RuntimeState::BlobStorage::Release(Blob
 size_t AssetSuite::Internal::RuntimeState::BlobStorage::LiveCount() const noexcept
 {
 	size_t count = 0;
-	for (const auto& storedBlob : blobs)
+	for (const auto& slot : slots)
 	{
-		if (storedBlob->IsLive())
+		if (slot.blob)
 		{
 			++count;
 		}
 	}
 
 	return count;
+}
+
+size_t AssetSuite::Internal::RuntimeState::BlobStorage::SlotCapacity() const noexcept
+{
+	return slots.size();
 }
 
 bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -59,7 +59,7 @@ namespace AssetSuite::Internal
 
 		struct FileLoader
 		{
-			ErrorCode LoadToMemory(const std::filesystem::path& fileName, bool isBinary, std::vector<BYTE>& output) const;
+			ErrorCode LoadToMemory(const std::filesystem::path& fileName, bool isBinary, std::vector<uint8_t>& output) const;
 		};
 
 		struct BlobStorage
@@ -67,11 +67,20 @@ namespace AssetSuite::Internal
 			BlobHandle Create(Blob blob);
 			bool Owns(BlobHandle blob) const noexcept;
 			bool IsLive(BlobHandle blob) const noexcept;
+			const Blob* Get(BlobHandle blob) const noexcept;
 			Result Release(BlobHandle* blob) noexcept;
 			size_t LiveCount() const noexcept;
+			size_t SlotCapacity() const noexcept;
 
 		private:
-			std::vector<std::unique_ptr<AssetSuiteBlob_t>> blobs;
+			struct Slot
+			{
+				std::unique_ptr<Blob> blob;
+				uint32_t generation = 1;
+			};
+
+			std::vector<Slot> slots;
+			std::vector<size_t> freeSlots;
 		};
 
 		struct CodecRegistry
@@ -133,7 +142,7 @@ namespace AssetSuite::Internal
 		FileInfo fileInfo;
 		ImageInfo imageInfo;
 		MeshInfo meshInfo;
-		std::vector<BYTE> rawBuffer;
+		std::vector<uint8_t> rawBuffer;
 		std::vector<BYTE> decodedBuffer;
 		std::vector<BYTE> formattedBuffer;
 		CodecStorage codecs;

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <Windows.h>
 
+#include "AssetSuiteBlob.h"
+
 #include "../common/ImageDescriptor.h"
 #include "../common/ImageDecoder.h"
 #include "../common/MeshDecoder.h"
@@ -58,6 +60,18 @@ namespace AssetSuite::Internal
 		struct FileLoader
 		{
 			ErrorCode LoadToMemory(const std::filesystem::path& fileName, bool isBinary, std::vector<BYTE>& output) const;
+		};
+
+		struct BlobStorage
+		{
+			BlobHandle Create(Blob blob);
+			bool Owns(BlobHandle blob) const noexcept;
+			bool IsLive(BlobHandle blob) const noexcept;
+			Result Release(BlobHandle* blob) noexcept;
+			size_t LiveCount() const noexcept;
+
+		private:
+			std::vector<std::unique_ptr<AssetSuiteBlob_t>> blobs;
 		};
 
 		struct CodecRegistry
@@ -126,6 +140,7 @@ namespace AssetSuite::Internal
 		AllocatorPolicy allocatorPolicy;
 		Diagnostics diagnostics;
 		FileLoader fileLoader;
+		BlobStorage blobStorage;
 		CodecRegistry codecRegistry;
 	};
 }

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <cstddef>
 #include <filesystem>
 #include <memory>
@@ -64,6 +65,8 @@ namespace AssetSuite::Internal
 
 		struct BlobStorage
 		{
+			BlobStorage();
+
 			BlobHandle Create(Blob blob);
 			bool Owns(BlobHandle blob) const noexcept;
 			bool IsLive(BlobHandle blob) const noexcept;
@@ -79,6 +82,7 @@ namespace AssetSuite::Internal
 				uint32_t generation = 1;
 			};
 
+			uint32_t contextId = 0;
 			std::vector<Slot> slots;
 			std::vector<size_t> freeSlots;
 		};

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -36,9 +36,9 @@ The public SDK surface is guarded by `PublicHeaderCompile`, `PublicHeaderHygiene
 
 `Internal::Blob` stores raw asset bytes in runtime-owned memory and copies minimal source metadata into the runtime object. The metadata currently tracks the original source path, source extension, and best-known public `AssetFormat` derived from the extension when possible.
 
-`BlobHandle` is treated as an opaque slot/generation token by the runtime. The public type remains pointer-shaped for ABI opacity, but blob validation decodes the token and never dereferences the handle value directly.
+`BlobHandle` is treated as an opaque context/slot/generation token by the runtime. The public type remains pointer-shaped for ABI opacity, but blob validation decodes the token and never dereferences the handle value directly. This token encoding requires a 64-bit target and is guarded by a compile-time assertion.
 
-`RuntimeState::BlobStorage` owns reusable blob slots for one context. `ReleaseBlob` clears the blob payload, advances the slot generation, returns the slot to the free list, and nulls the caller's handle. Copied stale handles are rejected by generation mismatch, and handles from another context are rejected because each context validates against only its own slot table.
+`RuntimeState::BlobStorage` owns reusable blob slots for one context. `ReleaseBlob` clears the blob payload, advances the slot generation, returns the slot to the free list, and nulls the caller's handle. Copied stale handles are rejected by generation mismatch, and handles from another context are rejected by context-id mismatch before slot lookup.
 
 ## Deferred Scope
 

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -11,7 +11,7 @@ The runtime currently owns:
 - allocator policy placeholders
 - diagnostics storage
 - file loading support
-- private blob representations for raw asset bytes and copied source metadata
+- private blob handle storage, raw bytes, and copied source metadata
 - source file metadata
 - raw, decoded, and formatted buffers
 - transient image and mesh metadata
@@ -36,13 +36,14 @@ The public SDK surface is guarded by `PublicHeaderCompile`, `PublicHeaderHygiene
 
 `Internal::Blob` stores raw asset bytes in runtime-owned memory and copies minimal source metadata into the runtime object. The metadata currently tracks the original source path, source extension, and best-known public `AssetFormat` derived from the extension when possible.
 
-`AssetSuiteBlob_t` is the private bridge behind `BlobHandle`. It owns one `Internal::Blob` and remains outside the installed SDK headers.
+`AssetSuiteBlob_t` is the private bridge behind `BlobHandle`. It owns one `Internal::Blob` while the handle is live and remains outside the installed SDK headers.
+
+`RuntimeState::BlobStorage` owns all blob bridge objects for one context. `ReleaseBlob` clears the blob payload and nulls the caller's handle, but the inactive bridge remains in the owning context until context destruction so copied stale handles can be rejected deterministically. Handles from another context are rejected because each context validates against only its own blob storage.
 
 ## Deferred Scope
 
 This runtime layer is intentionally foundational. The following work is deferred to later stories:
 
-- blob registry storage and validated lifetime ownership
 - image and mesh child-handle tracking
 - shared file loading APIs
 - codec probing and richer format detection

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -11,6 +11,7 @@ The runtime currently owns:
 - allocator policy placeholders
 - diagnostics storage
 - file loading support
+- private blob representations for raw asset bytes and copied source metadata
 - source file metadata
 - raw, decoded, and formatted buffers
 - transient image and mesh metadata
@@ -31,11 +32,17 @@ Runtime headers under `source/runtime` are private implementation files. They mu
 
 The public SDK surface is guarded by `PublicHeaderCompile`, `PublicHeaderHygiene.ps1`, and `AssertPublicInstallSurface.ps1`. These checks reject private runtime names in public headers and verify that the installed include tree contains only `AssetSuite/*.h`.
 
+## Blob Representation
+
+`Internal::Blob` stores raw asset bytes in runtime-owned memory and copies minimal source metadata into the runtime object. The metadata currently tracks the original source path, source extension, and best-known public `AssetFormat` derived from the extension when possible.
+
+`AssetSuiteBlob_t` is the private bridge behind `BlobHandle`. It owns one `Internal::Blob` and remains outside the installed SDK headers.
+
 ## Deferred Scope
 
 This runtime layer is intentionally foundational. The following work is deferred to later stories:
 
-- blob creation and lifetime ownership
+- blob registry storage and validated lifetime ownership
 - image and mesh child-handle tracking
 - shared file loading APIs
 - codec probing and richer format detection

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -36,9 +36,9 @@ The public SDK surface is guarded by `PublicHeaderCompile`, `PublicHeaderHygiene
 
 `Internal::Blob` stores raw asset bytes in runtime-owned memory and copies minimal source metadata into the runtime object. The metadata currently tracks the original source path, source extension, and best-known public `AssetFormat` derived from the extension when possible.
 
-`AssetSuiteBlob_t` is the private bridge behind `BlobHandle`. It owns one `Internal::Blob` while the handle is live and remains outside the installed SDK headers.
+`BlobHandle` is treated as an opaque slot/generation token by the runtime. The public type remains pointer-shaped for ABI opacity, but blob validation decodes the token and never dereferences the handle value directly.
 
-`RuntimeState::BlobStorage` owns all blob bridge objects for one context. `ReleaseBlob` clears the blob payload and nulls the caller's handle, but the inactive bridge remains in the owning context until context destruction so copied stale handles can be rejected deterministically. Handles from another context are rejected because each context validates against only its own blob storage.
+`RuntimeState::BlobStorage` owns reusable blob slots for one context. `ReleaseBlob` clears the blob payload, advances the slot generation, returns the slot to the free list, and nulls the caller's handle. Copied stale handles are rejected by generation mismatch, and handles from another context are rejected because each context validates against only its own slot table.
 
 ## Deferred Scope
 

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -42,6 +42,7 @@ namespace GeneralUnitTests
 			AssertResultString(AssetSuite::Result::ErrorOutputBufferTooSmall, "Error: output buffer too small");
 			AssertResultString(AssetSuite::Result::ErrorOutOfMemory, "Error: out of memory");
 			AssertResultString(AssetSuite::Result::ErrorInvalidContext, "Error: invalid context");
+			AssertResultString(AssetSuite::Result::ErrorInvalidHandle, "Error: invalid handle");
 			AssertResultString(AssetSuite::Result::ErrorUnknown, "Error: unknown");
 		}
 

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -458,19 +458,23 @@ namespace GeneralUnitTests
 		{
 			AssetSuite::ContextHandle firstContext = nullptr;
 			AssetSuite::ContextHandle secondContext = nullptr;
-			AssetSuite::BlobHandle blob = nullptr;
+			AssetSuite::BlobHandle firstBlob = nullptr;
+			AssetSuite::BlobHandle secondBlob = nullptr;
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &firstContext));
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &secondContext));
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(firstContext, "test_file.xyz", &blob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(firstContext, "test_file.xyz", &firstBlob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(secondContext, "test_file.xyz", &secondBlob));
+			Assert::IsFalse(firstBlob == secondBlob);
 
-			const auto result = AssetSuite::ReleaseBlob(secondContext, &blob);
+			const auto result = AssetSuite::ReleaseBlob(secondContext, &firstBlob);
 
 			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == result);
-			Assert::IsNotNull(blob);
+			Assert::IsNotNull(firstBlob);
 			Assert::AreEqual(static_cast<size_t>(1), firstContext->Runtime().BlobStorage().LiveCount());
-			Assert::AreEqual(static_cast<size_t>(0), secondContext->Runtime().BlobStorage().LiveCount());
+			Assert::AreEqual(static_cast<size_t>(1), secondContext->Runtime().BlobStorage().LiveCount());
 
-			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(firstContext, &blob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(secondContext, &secondBlob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(firstContext, &firstBlob));
 			DestroyContextForCleanup(secondContext);
 			DestroyContextForCleanup(firstContext);
 		}

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -1,13 +1,66 @@
 #pragma warning (disable : 4251)
 #include <CppUnitTest.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
 #include "../source/common/AssetSuite.h"
 #include "../source/common/AssetSuiteContext.h"
+#include "../source/runtime/AssetSuiteBlob.h"
 #include "../source/runtime/AssetSuiteRuntime.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace GeneralUnitTests
 {
+	TEST_CLASS(RuntimeBlobTests)
+	{
+	public:
+		TEST_METHOD(BlobStoresRawBytesAndMetadata)
+		{
+			std::vector<uint8_t> bytes = { 0x01, 0x02, 0x03, 0x04 };
+			const auto metadata = AssetSuite::Internal::MakeBlobSourceMetadata("textures/albedo.png");
+
+			AssetSuite::Internal::Blob blob(std::move(bytes), metadata);
+			const auto desc = blob.Describe();
+
+			Assert::AreEqual(static_cast<uint64_t>(4), blob.ByteSize());
+			Assert::IsNotNull(blob.Data());
+			Assert::AreEqual(static_cast<uint8_t>(0x01), blob.Data()[0]);
+			Assert::AreEqual(true, blob.SourceMetadata().sourcePath == "textures/albedo.png");
+			Assert::AreEqual(true, blob.SourceMetadata().extension == ".png");
+			Assert::AreEqual(true, AssetSuite::AssetFormat::PNG == blob.SourceMetadata().format);
+			Assert::AreEqual(static_cast<uint32_t>(sizeof(AssetSuite::BlobDesc)), desc.structSize);
+			Assert::AreEqual(static_cast<uint64_t>(4), desc.byteSize);
+			Assert::AreEqual(true, AssetSuite::AssetFormat::PNG == desc.format);
+			Assert::AreEqual(static_cast<uint32_t>(0), desc.flags);
+		}
+
+		TEST_METHOD(BlobMetadataUsesUnknownFormatForUnsupportedExtension)
+		{
+			const auto metadata = AssetSuite::Internal::MakeBlobSourceMetadata("data/source.asset");
+
+			Assert::AreEqual(true, metadata.sourcePath == "data/source.asset");
+			Assert::AreEqual(true, metadata.extension == ".asset");
+			Assert::AreEqual(true, AssetSuite::AssetFormat::Unknown == metadata.format);
+		}
+
+		TEST_METHOD(BlobHandleBridgeOwnsPrivateBlobRepresentation)
+		{
+			std::vector<uint8_t> bytes = { 0x0a, 0x0b };
+			AssetSuite::Internal::Blob blob(
+				std::move(bytes),
+				AssetSuite::Internal::MakeBlobSourceMetadata("meshes/cube.obj"));
+
+			AssetSuite::AssetSuiteBlob_t handle(std::move(blob));
+
+			Assert::AreEqual(static_cast<uint64_t>(2), handle.Blob().ByteSize());
+			Assert::AreEqual(static_cast<uint8_t>(0x0b), handle.Blob().Data()[1]);
+			Assert::AreEqual(true, AssetSuite::AssetFormat::WavefrontObj == handle.Blob().SourceMetadata().format);
+		}
+	};
+
 	TEST_CLASS(PublicApiTests)
 	{
 	public:

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -348,6 +348,134 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(context);
 		}
 
+		TEST_METHOD(LoadFileCreatesRuntimeOwnedBlob)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			const auto result = AssetSuite::LoadFile(context, "test_file.xyz", &blob);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNotNull(blob);
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().BlobStorage().LiveCount());
+			Assert::AreEqual(static_cast<uint64_t>(102), blob->Blob().ByteSize());
+			Assert::AreEqual(true, AssetSuite::AssetFormat::Unknown == blob->Blob().SourceMetadata().format);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(LoadFileRejectsNullContext)
+		{
+			AssetSuite::BlobHandle blob = nullptr;
+
+			const auto result = AssetSuite::LoadFile(nullptr, "test_file.xyz", &blob);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == result);
+			Assert::IsNull(blob);
+		}
+
+		TEST_METHOD(LoadFileRejectsInvalidArguments)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == AssetSuite::LoadFile(context, nullptr, &blob));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == AssetSuite::LoadFile(context, "test_file.xyz", nullptr));
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, "test_file.xyz", &blob));
+			AssetSuite::BlobHandle originalBlob = blob;
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == AssetSuite::LoadFile(context, "test_file.xyz", &blob));
+			Assert::IsTrue(originalBlob == blob);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(LoadFileReturnsFileNotFoundForMissingFile)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			const auto result = AssetSuite::LoadFile(context, "missing_blob_source.bin", &blob);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorFileNotFound == result);
+			Assert::IsNull(blob);
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(ReleaseBlobClearsHandleAndInvalidatesStorage)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, "test_file.xyz", &blob));
+
+			const auto result = AssetSuite::ReleaseBlob(context, &blob);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNull(blob);
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(ReleaseBlobRejectsInvalidInputs)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == AssetSuite::ReleaseBlob(nullptr, &blob));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::ReleaseBlob(context, nullptr));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::ReleaseBlob(context, &blob));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(ReleaseBlobRejectsDoubleReleaseAndStaleCopiedHandle)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, "test_file.xyz", &blob));
+			AssetSuite::BlobHandle copiedBlob = blob;
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::ReleaseBlob(context, &blob));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::ReleaseBlob(context, &copiedBlob));
+			Assert::IsNotNull(copiedBlob);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(ReleaseBlobRejectsWrongContext)
+		{
+			AssetSuite::ContextHandle firstContext = nullptr;
+			AssetSuite::ContextHandle secondContext = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &firstContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &secondContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(firstContext, "test_file.xyz", &blob));
+
+			const auto result = AssetSuite::ReleaseBlob(secondContext, &blob);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == result);
+			Assert::IsNotNull(blob);
+			Assert::AreEqual(static_cast<size_t>(1), firstContext->Runtime().BlobStorage().LiveCount());
+			Assert::AreEqual(static_cast<size_t>(0), secondContext->Runtime().BlobStorage().LiveCount());
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(firstContext, &blob));
+			DestroyContextForCleanup(secondContext);
+			DestroyContextForCleanup(firstContext);
+		}
+
 		TEST_METHOD(RuntimeDiagnosticsAreContextScoped)
 		{
 			AssetSuite::ContextHandle firstContext = nullptr;

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -46,18 +46,15 @@ namespace GeneralUnitTests
 			Assert::AreEqual(true, AssetSuite::AssetFormat::Unknown == metadata.format);
 		}
 
-		TEST_METHOD(BlobHandleBridgeOwnsPrivateBlobRepresentation)
+		TEST_METHOD(BlobMetadataNormalizesExtensionCase)
 		{
-			std::vector<uint8_t> bytes = { 0x0a, 0x0b };
-			AssetSuite::Internal::Blob blob(
-				std::move(bytes),
-				AssetSuite::Internal::MakeBlobSourceMetadata("meshes/cube.obj"));
+			const auto pngMetadata = AssetSuite::Internal::MakeBlobSourceMetadata("textures/ALBEDO.PNG");
+			const auto objMetadata = AssetSuite::Internal::MakeBlobSourceMetadata("meshes/CUBE.OBJ");
 
-			AssetSuite::AssetSuiteBlob_t handle(std::move(blob));
-
-			Assert::AreEqual(static_cast<uint64_t>(2), handle.Blob().ByteSize());
-			Assert::AreEqual(static_cast<uint8_t>(0x0b), handle.Blob().Data()[1]);
-			Assert::AreEqual(true, AssetSuite::AssetFormat::WavefrontObj == handle.Blob().SourceMetadata().format);
+			Assert::AreEqual(true, pngMetadata.extension == ".PNG");
+			Assert::AreEqual(true, AssetSuite::AssetFormat::PNG == pngMetadata.format);
+			Assert::AreEqual(true, objMetadata.extension == ".OBJ");
+			Assert::AreEqual(true, AssetSuite::AssetFormat::WavefrontObj == objMetadata.format);
 		}
 	};
 
@@ -359,8 +356,10 @@ namespace GeneralUnitTests
 			Assert::AreEqual(true, AssetSuite::Result::Success == result);
 			Assert::IsNotNull(blob);
 			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().BlobStorage().LiveCount());
-			Assert::AreEqual(static_cast<uint64_t>(102), blob->Blob().ByteSize());
-			Assert::AreEqual(true, AssetSuite::AssetFormat::Unknown == blob->Blob().SourceMetadata().format);
+			const auto* storedBlob = context->Runtime().BlobStorage().Get(blob);
+			Assert::IsNotNull(storedBlob);
+			Assert::AreEqual(static_cast<uint64_t>(102), storedBlob->ByteSize());
+			Assert::AreEqual(true, AssetSuite::AssetFormat::Unknown == storedBlob->SourceMetadata().format);
 
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
 			DestroyContextForCleanup(context);
@@ -474,6 +473,33 @@ namespace GeneralUnitTests
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(firstContext, &blob));
 			DestroyContextForCleanup(secondContext);
 			DestroyContextForCleanup(firstContext);
+		}
+
+		TEST_METHOD(BlobStorageReusesReleasedSlotsAndRejectsOldGenerations)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, "test_file.xyz", &blob));
+			AssetSuite::BlobHandle staleBlob = blob;
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().BlobStorage().SlotCapacity());
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+
+			for (int iteration = 0; iteration < 8; ++iteration)
+			{
+				Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, "test_file.xyz", &blob));
+				Assert::AreEqual(static_cast<size_t>(1), context->Runtime().BlobStorage().LiveCount());
+				Assert::AreEqual(static_cast<size_t>(1), context->Runtime().BlobStorage().SlotCapacity());
+				Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::ReleaseBlob(context, &staleBlob));
+				Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			}
+
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().BlobStorage().SlotCapacity());
+			Assert::IsNotNull(staleBlob);
+
+			DestroyContextForCleanup(context);
 		}
 
 		TEST_METHOD(RuntimeDiagnosticsAreContextScoped)

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -115,6 +115,12 @@ static_assert(std::is_same_v<
 		AssetSuite::LoggingCallback,
 		AssetSuite::LogLevel,
 		void*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::LoadFile),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, const char*, AssetSuite::BlobHandle*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::ReleaseBlob),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::BlobHandle*)>);
 
 void PublicLoggingCallback(AssetSuite::LogLevel, const char*, void*)
 {
@@ -145,6 +151,8 @@ int main()
 		nullptr,
 		AssetSuite::LogLevel::Trace,
 		nullptr);
+	const AssetSuite::Result loadNullPathResult = AssetSuite::LoadFile(context, nullptr, &blob);
+	const AssetSuite::Result releaseNullBlobResult = AssetSuite::ReleaseBlob(context, &blob);
 	const AssetSuite::Result destroyExplicitResult = AssetSuite::DestroyContext(&context);
 
 	return context || blob || image || mesh ||
@@ -157,5 +165,7 @@ int main()
 		createExplicitResult == AssetSuite::Result::ErrorUnknown ||
 		setLoggingResult == AssetSuite::Result::ErrorUnknown ||
 		unregisterLoggingResult == AssetSuite::Result::ErrorUnknown ||
+		loadNullPathResult == AssetSuite::Result::ErrorUnknown ||
+		releaseNullBlobResult == AssetSuite::Result::ErrorUnknown ||
 		destroyExplicitResult == AssetSuite::Result::ErrorUnknown;
 }


### PR DESCRIPTION
## Summary

Implements the issue #41 blob lifecycle path for the AssetSuite 2.0 handle runtime.

This PR adds the public blob contract, private blob representation, context-owned blob storage, `LoadFile`, `ReleaseBlob`, lifecycle coverage, and ownership documentation. Blob bytes and copied source metadata are owned by the runtime context, and invalid/stale/wrong-context blob handles now return deterministic public errors.

## Changes

- Adds `LoadFile` and `ReleaseBlob` to the public SDK surface.
- Adds `Result::ErrorInvalidHandle` and public-header validation for the new API signatures.
- Introduces private `Internal::Blob` and `AssetSuiteBlob_t` behind `BlobHandle`.
- Adds context-owned `RuntimeState::BlobStorage` for blob bridge ownership and stale-handle validation.
- Wires `LoadFile` through the existing runtime file loader and maps missing files to `ErrorFileNotFound`.
- Wires `ReleaseBlob` through runtime storage and clears the caller's handle on success.
- Adds lifecycle tests for success, invalid input, missing file, double release, stale copied handles, and wrong-context release.
- Updates public comments and runtime notes for ownership, synchronization, and post-release invalidation rules.

## Validation

Targeted MSVC compiles were run for the touched source files through the Visual Studio developer environment:

- `source/runtime/AssetSuiteBlob.cpp`
- `source/runtime/AssetSuiteRuntimeState.cpp`
- `source/runtime/AssetSuiteRuntime.cpp`
- `source/common/AssetSuite.cpp`
- `validation/public_header_compile/PublicHeaderCompile.cpp`
- `unit_tests/GeneralUnitTests.cpp`

Full MSBuild remains blocked in this local shell by a duplicate `Path`/`PATH` environment issue that causes MSBuild/CL process launch to fail before source diagnostics.