### PR TITLE
[codex] Implement shared file loading result mapping

### DIFF
--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -51,7 +51,8 @@ namespace AssetSuite
 	// Passing a null context returns Result::ErrorInvalidContext. Passing a
 	// null filePath, null outBlob, or non-null *outBlob returns
 	// Result::ErrorInvalidArgument. Missing files return
-	// Result::ErrorFileNotFound.
+	// Result::ErrorFileNotFound. Existing files that cannot be opened or read
+	// return Result::ErrorIoFailure.
 	ASSET_SUITE_API Result LoadFile(ContextHandle context, const char* filePath, BlobHandle* outBlob);
 
 	// Releases a runtime-owned blob and sets the caller's handle to nullptr on

--- a/include/AssetSuite/AssetSuiteTypes.h
+++ b/include/AssetSuite/AssetSuiteTypes.h
@@ -19,6 +19,7 @@ namespace AssetSuite
 		ErrorOutOfMemory = -6,
 		ErrorInvalidContext = -7,
 		ErrorInvalidHandle = -8,
+		ErrorIoFailure = -9,
 		ErrorUnknown = -1000
 	};
 

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -51,6 +51,8 @@ namespace
 			return AssetSuite::Result::Success;
 		case AssetSuite::ErrorCode::NonExistingFile:
 			return AssetSuite::Result::ErrorFileNotFound;
+		case AssetSuite::ErrorCode::IoFailure:
+			return AssetSuite::Result::ErrorIoFailure;
 		default:
 			return AssetSuite::Result::ErrorUnknown;
 		}
@@ -110,6 +112,8 @@ const char* AssetSuite::GetResultString(Result result)
 		return "Error: invalid context";
 	case Result::ErrorInvalidHandle:
 		return "Error: invalid handle";
+	case Result::ErrorIoFailure:
+		return "Error: IO failure";
 	case Result::ErrorUnknown:
 		return "Error: unknown";
 	default:

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -11,6 +11,7 @@
 #include "../ppm/PpmEncoder.h"
 #include "../bypass/BypassEncoder.h"
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <new>
@@ -53,6 +54,24 @@ namespace
 		default:
 			return AssetSuite::Result::ErrorUnknown;
 		}
+	}
+
+	AssetSuite::ErrorCode LoadRuntimeFileToMemory(
+		AssetSuite::Internal::RuntimeContext& runtime,
+		const std::filesystem::path& filePath,
+		bool isBinary,
+		std::vector<uint8_t>& output)
+	{
+		return runtime.FileLoader().LoadToMemory(filePath, isBinary, output);
+	}
+
+	AssetSuite::ErrorCode LoadRuntimeFileToMemory(
+		AssetSuite::Internal::RuntimeState& runtimeState,
+		const std::filesystem::path& filePath,
+		bool isBinary,
+		std::vector<uint8_t>& output)
+	{
+		return runtimeState.fileLoader.LoadToMemory(filePath, isBinary, output);
 	}
 }
 
@@ -153,7 +172,7 @@ AssetSuite::Result AssetSuite::LoadFile(ContextHandle context, const char* fileP
 	}
 
 	std::vector<uint8_t> rawBytes;
-	const ErrorCode loadResult = context->Runtime().FileLoader().LoadToMemory(filePath, true, rawBytes);
+	const ErrorCode loadResult = LoadRuntimeFileToMemory(context->Runtime(), filePath, true, rawBytes);
 	const Result mappedResult = MapFileLoadResult(loadResult);
 	if (mappedResult != Result::Success)
 	{
@@ -462,7 +481,7 @@ void AssetSuite::Manager::StoreImageToFile(const std::string& filePathAndName, c
 AssetSuite::ErrorCode AssetSuite::Manager::LoadFileToMemory(const std::string& fileName, bool isBinary)
 {
       auto& state = State();
-      const ErrorCode result = state.fileLoader.LoadToMemory(fileName, isBinary, state.rawBuffer);
+      const ErrorCode result = ::LoadRuntimeFileToMemory(state, fileName, isBinary, state.rawBuffer);
       if (result != ErrorCode::OK)
       {
             state.diagnostics.Add(result, "Failed to load file into runtime memory.");

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -488,6 +488,7 @@ AssetSuite::ErrorCode AssetSuite::Manager::LoadFileToMemory(const std::string& f
       const ErrorCode result = ::LoadRuntimeFileToMemory(state, fileName, isBinary, state.rawBuffer);
       if (result != ErrorCode::OK)
       {
+            state.rawBuffer.clear();
             state.diagnostics.Add(result, "Failed to load file into runtime memory.");
       }
 

--- a/source/common/AssetSuite.h
+++ b/source/common/AssetSuite.h
@@ -51,6 +51,7 @@ namespace AssetSuite
 		ColorTypeNotSupported = -3,
 		RawBufferIsEmpty = -4,
 		DecodedBufferIsEmpty = -5,
+		IoFailure = -6,
 		Undefined = -1000
 	};
 

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -194,8 +194,8 @@ AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemo
 	}
 
 	const std::streamoff size = endPosition - beginPosition;
-	if (size > static_cast<std::streamoff>(std::numeric_limits<std::streamsize>::max()) ||
-		size > static_cast<std::streamoff>(std::numeric_limits<size_t>::max()))
+	if (size > static_cast<std::streamoff>((std::numeric_limits<std::streamsize>::max)()) ||
+		size > static_cast<std::streamoff>((std::numeric_limits<size_t>::max)()))
 	{
 		return ErrorCode::IoFailure;
 	}

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -194,8 +194,9 @@ AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemo
 	}
 
 	const std::streamoff size = endPosition - beginPosition;
-	if (size > static_cast<std::streamoff>((std::numeric_limits<std::streamsize>::max)()) ||
-		size > static_cast<std::streamoff>((std::numeric_limits<size_t>::max)()))
+	const auto unsignedSize = static_cast<uintmax_t>(size);
+	if (unsignedSize > static_cast<uintmax_t>((std::numeric_limits<std::streamsize>::max)()) ||
+		unsignedSize > static_cast<uintmax_t>((std::numeric_limits<size_t>::max)()))
 	{
 		return ErrorCode::IoFailure;
 	}

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -7,9 +7,11 @@
 #include "../bypass/BypassEncoder.h"
 
 #include <fstream>
+#include <limits>
 #include <new>
 #include <atomic>
 #include <cstdint>
+#include <system_error>
 #include <utility>
 
 namespace
@@ -151,36 +153,70 @@ AssetSuite::ErrorCode AssetSuite::Internal::RuntimeState::FileLoader::LoadToMemo
 	bool isBinary,
 	std::vector<uint8_t>& output) const
 {
-	if (!std::filesystem::exists(fileName))
+	std::error_code fileStatusError;
+	if (!std::filesystem::exists(fileName, fileStatusError))
 	{
+		if (fileStatusError)
+		{
+			return ErrorCode::IoFailure;
+		}
+
 		return ErrorCode::NonExistingFile;
 	}
 
-	output.clear();
+	if (!std::filesystem::is_regular_file(fileName, fileStatusError) || fileStatusError)
+	{
+		return ErrorCode::IoFailure;
+	}
 
 	std::ifstream file(fileName.c_str(), std::ios::in | std::ios::ate | std::ios::binary);
-	std::streamsize size = 0;
-
-	if (file.seekg(0, std::ios::end).good())
+	if (!file.is_open())
 	{
-		size = file.tellg();
+		return ErrorCode::IoFailure;
 	}
 
-	if (file.seekg(0, std::ios::beg).good())
+	const std::streampos endPosition = file.tellg();
+	if (endPosition == std::streampos(-1))
 	{
-		size -= file.tellg();
+		return ErrorCode::IoFailure;
 	}
 
+	file.seekg(0, std::ios::beg);
+	if (!file.good())
+	{
+		return ErrorCode::IoFailure;
+	}
+
+	const std::streampos beginPosition = file.tellg();
+	if (beginPosition == std::streampos(-1) || endPosition < beginPosition)
+	{
+		return ErrorCode::IoFailure;
+	}
+
+	const std::streamoff size = endPosition - beginPosition;
+	if (size > static_cast<std::streamoff>(std::numeric_limits<std::streamsize>::max()) ||
+		size > static_cast<std::streamoff>(std::numeric_limits<size_t>::max()))
+	{
+		return ErrorCode::IoFailure;
+	}
+
+	std::vector<uint8_t> loadedBytes;
 	if (size > 0)
 	{
-		output.resize(static_cast<size_t>(size));
-		file.read(reinterpret_cast<char*>(output.data()), size);
-		if (!isBinary)
+		loadedBytes.resize(static_cast<size_t>(size));
+		file.read(reinterpret_cast<char*>(loadedBytes.data()), static_cast<std::streamsize>(size));
+		if (file.gcount() != static_cast<std::streamsize>(size) || !file)
 		{
-			output.push_back('\0');
+			return ErrorCode::IoFailure;
 		}
 	}
 
+	if (!isBinary)
+	{
+		loadedBytes.push_back('\0');
+	}
+
+	output = std::move(loadedBytes);
 	return ErrorCode::OK;
 }
 

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -40,12 +40,17 @@ The public SDK surface is guarded by `PublicHeaderCompile`, `PublicHeaderHygiene
 
 `RuntimeState::BlobStorage` owns reusable blob slots for one context. `ReleaseBlob` clears the blob payload, advances the slot generation, returns the slot to the free list, and nulls the caller's handle. Copied stale handles are rejected by generation mismatch, and handles from another context are rejected by context-id mismatch before slot lookup.
 
+## File Loading
+
+`RuntimeState::FileLoader` is the shared file-read service for public blob loading and the legacy `Manager` image/mesh file entry points. Missing paths return `ErrorCode::NonExistingFile`, while existing paths that cannot be opened, sized, or fully read return `ErrorCode::IoFailure`.
+
+The public SDK adapter maps `NonExistingFile` to `Result::ErrorFileNotFound` and `IoFailure` to `Result::ErrorIoFailure`. Text-mode loads append a null terminator after successful reads; binary loads preserve the exact file bytes.
+
 ## Deferred Scope
 
 This runtime layer is intentionally foundational. The following work is deferred to later stories:
 
 - image and mesh child-handle tracking
-- shared file loading APIs
 - codec probing and richer format detection
 - public diagnostics reporting
 - allocator hooks wired into all internal allocations

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <utility>
 #include <vector>
+#include <Windows.h>
 
 #include "../source/common/AssetSuite.h"
 #include "../source/common/AssetSuiteContext.h"
@@ -13,8 +14,29 @@
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
+namespace
+{
+	std::filesystem::path GetCurrentModuleDirectory()
+	{
+		HMODULE module = nullptr;
+		GetModuleHandleExW(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			reinterpret_cast<LPCWSTR>(&GetCurrentModuleDirectory),
+			&module);
+
+		wchar_t modulePath[MAX_PATH] = {};
+		GetModuleFileNameW(module, modulePath, MAX_PATH);
+		return std::filesystem::path(modulePath).parent_path();
+	}
+}
+
 namespace GeneralUnitTests
 {
+	TEST_MODULE_INITIALIZE(ModuleInitialize)
+	{
+		std::filesystem::current_path(GetCurrentModuleDirectory());
+	}
+
 	TEST_CLASS(RuntimeBlobTests)
 	{
 	public:

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -734,6 +734,20 @@ namespace GeneralUnitTests
 			Assert::AreEqual(true, AssetSuite::ErrorCode::NonExistingFile == error);
 		}
 
+		TEST_METHOD(ImageFailedLoadClearsPreviousRawBuffer)
+		{
+			AssetSuite::Manager manager;
+
+			auto error = manager.ImageLoad("test_file.xyz");
+			Assert::AreEqual(true, AssetSuite::ErrorCode::OK == error);
+
+			error = manager.ImageLoad("non-existing-image.bmp");
+			Assert::AreEqual(true, AssetSuite::ErrorCode::NonExistingFile == error);
+
+			error = manager.ImageDecode(AssetSuite::ImageDecoders::Auto);
+			Assert::AreEqual(true, AssetSuite::ErrorCode::RawBufferIsEmpty == error);
+		}
+
 		TEST_METHOD(RawBufferIsEmpty)
 		{
 			// In this test we don't need real data
@@ -766,6 +780,20 @@ namespace GeneralUnitTests
 
 			auto error = manager.MeshLoad("non-existing-mesh.obj");
 			Assert::AreEqual(true, AssetSuite::ErrorCode::NonExistingFile == error);
+		}
+
+		TEST_METHOD(FailedMeshLoadClearsPreviousRawBuffer)
+		{
+			AssetSuite::Manager manager;
+
+			auto error = manager.MeshLoad("test_mesh.obj");
+			Assert::AreEqual(true, AssetSuite::ErrorCode::OK == error);
+
+			error = manager.MeshLoad("non-existing-mesh.obj");
+			Assert::AreEqual(true, AssetSuite::ErrorCode::NonExistingFile == error);
+
+			error = manager.MeshDecode(AssetSuite::MeshDecoders::Auto);
+			Assert::AreEqual(true, AssetSuite::ErrorCode::RawBufferIsEmpty == error);
 		}
 
 		TEST_METHOD(FileTypeNotSupported)

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <utility>
 #include <vector>
+#include <Windows.h>
 
 #include "../source/common/AssetSuite.h"
 #include "../source/common/AssetSuiteContext.h"
@@ -15,9 +16,72 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace
 {
-	std::filesystem::path GetTestAssetDirectory()
+	std::filesystem::path GetLoadedModuleDirectory()
 	{
-		return std::filesystem::path(__FILE__).parent_path().parent_path() / "test_images";
+		HMODULE module = nullptr;
+		if (!GetModuleHandleExW(
+			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+			reinterpret_cast<LPCWSTR>(&GetLoadedModuleDirectory),
+			&module))
+		{
+			return {};
+		}
+
+		wchar_t modulePath[MAX_PATH] = {};
+		if (GetModuleFileNameW(module, modulePath, MAX_PATH) == 0)
+		{
+			return {};
+		}
+
+		return std::filesystem::path(modulePath).parent_path();
+	}
+
+	bool ContainsTestAssets(const std::filesystem::path& directory)
+	{
+		return !directory.empty() && std::filesystem::exists(directory / "test_file.xyz");
+	}
+
+	std::filesystem::path FindTestAssetDirectory()
+	{
+		const std::filesystem::path moduleDirectory = GetLoadedModuleDirectory();
+		const std::filesystem::path currentDirectory = std::filesystem::current_path();
+		const std::filesystem::path sourceDirectory = std::filesystem::path(__FILE__).parent_path();
+
+		const std::filesystem::path candidates[] = {
+			currentDirectory,
+			moduleDirectory,
+			currentDirectory / "test_images",
+			moduleDirectory / "test_images",
+			sourceDirectory.parent_path() / "test_images"
+		};
+
+		for (const auto& candidate : candidates)
+		{
+			if (ContainsTestAssets(candidate))
+			{
+				return candidate;
+			}
+		}
+
+		for (std::filesystem::path cursor = currentDirectory; !cursor.empty(); cursor = cursor.parent_path())
+		{
+			if (ContainsTestAssets(cursor))
+			{
+				return cursor;
+			}
+
+			if (ContainsTestAssets(cursor / "test_images"))
+			{
+				return cursor / "test_images";
+			}
+
+			if (cursor == cursor.parent_path())
+			{
+				break;
+			}
+		}
+
+		return currentDirectory;
 	}
 }
 
@@ -25,7 +89,7 @@ namespace GeneralUnitTests
 {
 	TEST_MODULE_INITIALIZE(ModuleInitialize)
 	{
-		std::filesystem::current_path(GetTestAssetDirectory());
+		std::filesystem::current_path(FindTestAssetDirectory());
 	}
 
 	TEST_CLASS(RuntimeBlobTests)

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -2,6 +2,7 @@
 #include <CppUnitTest.h>
 
 #include <cstdint>
+#include <filesystem>
 #include <utility>
 #include <vector>
 
@@ -93,6 +94,7 @@ namespace GeneralUnitTests
 			AssertResultString(AssetSuite::Result::ErrorOutOfMemory, "Error: out of memory");
 			AssertResultString(AssetSuite::Result::ErrorInvalidContext, "Error: invalid context");
 			AssertResultString(AssetSuite::Result::ErrorInvalidHandle, "Error: invalid handle");
+			AssertResultString(AssetSuite::Result::ErrorIoFailure, "Error: IO failure");
 			AssertResultString(AssetSuite::Result::ErrorUnknown, "Error: unknown");
 		}
 
@@ -408,6 +410,55 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(context);
 		}
 
+		TEST_METHOD(LoadFileReturnsIoFailureForExistingNonFilePath)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			const auto result = AssetSuite::LoadFile(context, std::filesystem::current_path().string().c_str(), &blob);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorIoFailure == result);
+			Assert::IsNull(blob);
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeFileLoaderPreservesOutputOnIoFailure)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			std::vector<uint8_t> bytes = { 0xAB, 0xCD };
+
+			const auto result = context->Runtime().FileLoader().LoadToMemory(std::filesystem::current_path(), true, bytes);
+
+			Assert::AreEqual(true, AssetSuite::ErrorCode::IoFailure == result);
+			Assert::AreEqual(static_cast<size_t>(2), bytes.size());
+			Assert::AreEqual(static_cast<uint8_t>(0xAB), bytes[0]);
+			Assert::AreEqual(static_cast<uint8_t>(0xCD), bytes[1]);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeFileLoaderAddsTerminatorForTextLoads)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			std::vector<uint8_t> textBytes;
+			std::vector<uint8_t> binaryBytes;
+
+			const auto textResult = context->Runtime().FileLoader().LoadToMemory("test_mesh.obj", false, textBytes);
+			const auto binaryResult = context->Runtime().FileLoader().LoadToMemory("test_mesh.obj", true, binaryBytes);
+
+			Assert::AreEqual(true, AssetSuite::ErrorCode::OK == textResult);
+			Assert::AreEqual(true, AssetSuite::ErrorCode::OK == binaryResult);
+			Assert::AreEqual(binaryBytes.size() + 1, textBytes.size());
+			Assert::AreEqual(static_cast<uint8_t>('\0'), textBytes.back());
+
+			DestroyContextForCleanup(context);
+		}
+
 		TEST_METHOD(ReleaseBlobClearsHandleAndInvalidatesStorage)
 		{
 			AssetSuite::ContextHandle context = nullptr;
@@ -595,6 +646,15 @@ namespace GeneralUnitTests
 			manager.ImageLoad("test_file.xyz");
 			auto error = manager.ImageDecode(AssetSuite::ImageDecoders::Auto);
 			Assert::AreEqual(true, AssetSuite::ErrorCode::FileTypeNotSupported == error);
+		}
+
+		TEST_METHOD(ImageOpeningNonExistingFile)
+		{
+			AssetSuite::Manager manager;
+
+			auto error = manager.ImageLoad("non-existing-image.bmp");
+
+			Assert::AreEqual(true, AssetSuite::ErrorCode::NonExistingFile == error);
 		}
 
 		TEST_METHOD(RawBufferIsEmpty)

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -5,7 +5,6 @@
 #include <filesystem>
 #include <utility>
 #include <vector>
-#include <Windows.h>
 
 #include "../source/common/AssetSuite.h"
 #include "../source/common/AssetSuiteContext.h"
@@ -16,17 +15,9 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace
 {
-	std::filesystem::path GetCurrentModuleDirectory()
+	std::filesystem::path GetTestAssetDirectory()
 	{
-		HMODULE module = nullptr;
-		GetModuleHandleExW(
-			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-			reinterpret_cast<LPCWSTR>(&GetCurrentModuleDirectory),
-			&module);
-
-		wchar_t modulePath[MAX_PATH] = {};
-		GetModuleFileNameW(module, modulePath, MAX_PATH);
-		return std::filesystem::path(modulePath).parent_path();
+		return std::filesystem::path(__FILE__).parent_path().parent_path() / "test_images";
 	}
 }
 
@@ -34,7 +25,7 @@ namespace GeneralUnitTests
 {
 	TEST_MODULE_INITIALIZE(ModuleInitialize)
 	{
-		std::filesystem::current_path(GetCurrentModuleDirectory());
+		std::filesystem::current_path(GetTestAssetDirectory());
 	}
 
 	TEST_CLASS(RuntimeBlobTests)


### PR DESCRIPTION
## Summary

Implements issue #42 by making runtime file loading a stricter shared service with deterministic result mapping.

## Changes

- Added public `Result::ErrorIoFailure` and internal `ErrorCode::IoFailure`.
- Hardened `RuntimeState::FileLoader::LoadToMemory` to distinguish missing files from open, seek, sizing, and read failures.
- Kept public `LoadFile` and legacy image/mesh file entry points routed through the shared runtime loader.
- Mapped IO failures to the new public result and updated API comments/result strings.
- Added focused tests for successful loads, missing files, IO failures, output preservation, text null termination, stale legacy buffer cleanup, and legacy image/mesh behavior.
- Updated runtime notes for the shared file-loading contract.

## Review Follow-up

- Addressed stale `Manager::state.rawBuffer` behavior after failed legacy file loads.
- `Manager::LoadFileToMemory` now clears the persistent raw buffer on failed loads so later decode calls cannot consume stale bytes.
- Added image and mesh regressions for successful load -> failed load -> decode returning `RawBufferIsEmpty`.

## Validation

- Debug `UnitTest.vcxproj` build: passed.
- Debug unit tests: 154/154 passed.
- Release `UnitTest.vcxproj` build: passed.
- Release unit tests: 154/154 passed.
- Debug and Release `PublicHeaderCompile.vcxproj`: passed, including public header hygiene and install surface checks.
- Debug and Release `LegacyDemoApplication.vcxproj`: passed.

Note: direct `build/AssetSuite.sln` invocation still exits early without useful diagnostics in this local environment, so validation used the concrete generated projects instead.