### PR TITLE
[codex] Build internal codec registry probing

### DIFF
--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -281,7 +281,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::ImageDecode(ImageDecoders decoder)
 
       if (decoder == ImageDecoders::Auto)
       {
-            decoder = state.codecRegistry.ResolveImageDecoder(state.fileInfo.extension);
+            decoder = state.codecRegistry.ProbeImageDecoder(
+                  state.fileInfo.extension,
+                  state.rawBuffer.data(),
+                  state.rawBuffer.size());
             if (decoder == ImageDecoders::Auto)
             {
                   state.diagnostics.Add(ErrorCode::FileTypeNotSupported, "Image file type is not supported.");
@@ -361,7 +364,10 @@ AssetSuite::ErrorCode AssetSuite::Manager::MeshDecode(MeshDecoders decoder)
 
       if (decoder == MeshDecoders::Auto)
       {
-            decoder = state.codecRegistry.ResolveMeshDecoder(state.fileInfo.extension);
+            decoder = state.codecRegistry.ProbeMeshDecoder(
+                  state.fileInfo.extension,
+                  state.rawBuffer.data(),
+                  state.rawBuffer.size());
             if (decoder == MeshDecoders::Auto)
             {
                   state.diagnostics.Add(ErrorCode::FileTypeNotSupported, "Mesh file type is not supported.");

--- a/source/common/ImageEncoder.h
+++ b/source/common/ImageEncoder.h
@@ -8,6 +8,8 @@ namespace AssetSuite
 {
 	class ImageEncoder
 	{
+	public:
+		virtual ~ImageEncoder() = default;
 		virtual std::vector<BYTE> Encode(const std::vector<BYTE>& buffer, const ImageDescriptor& descriptor) = 0;
 	};
 }

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -134,6 +134,8 @@ namespace
 
 		const char* text = reinterpret_cast<const char*>(data);
 		size_t offset = 0;
+		bool hasVertex = false;
+		bool hasFace = false;
 		while (offset < size)
 		{
 			while (offset < size && (text[offset] == ' ' || text[offset] == '\t' || text[offset] == '\r' || text[offset] == '\n'))
@@ -154,15 +156,16 @@ namespace
 
 			const size_t lineLength = offset - lineStart;
 			const char* line = text + lineStart;
-			if (lineLength > 0 &&
-				(StartsWithToken(line, lineLength, "v") ||
-					StartsWithToken(line, lineLength, "vn") ||
-					StartsWithToken(line, lineLength, "vt") ||
-					StartsWithToken(line, lineLength, "f") ||
-					StartsWithToken(line, lineLength, "o") ||
-					StartsWithToken(line, lineLength, "g") ||
-					StartsWithToken(line, lineLength, "mtllib") ||
-					StartsWithToken(line, lineLength, "usemtl")))
+			if (StartsWithToken(line, lineLength, "v"))
+			{
+				hasVertex = true;
+			}
+			else if (StartsWithToken(line, lineLength, "f"))
+			{
+				hasFace = true;
+			}
+
+			if (hasVertex && hasFace)
 			{
 				return true;
 			}
@@ -708,13 +711,13 @@ AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageDecoderRecord(ImageD
 		return nullptr;
 	}
 
-	for (const CodecRecord& record : records)
+	for (auto record = records.rbegin(); record != records.rend(); ++record)
 	{
-		if (record.assetKind == CodecRegistry::AssetKind::Image &&
-			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
-			record.imageDecoder == decoder)
+		if (record->assetKind == CodecRegistry::AssetKind::Image &&
+			(record->capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			record->imageDecoder == decoder)
 		{
-			return &record;
+			return &(*record);
 		}
 	}
 
@@ -729,13 +732,13 @@ AssetSuite::Internal::RuntimeState::CodecRegistry::FindMeshDecoderRecord(MeshDec
 		return nullptr;
 	}
 
-	for (const CodecRecord& record : records)
+	for (auto record = records.rbegin(); record != records.rend(); ++record)
 	{
-		if (record.assetKind == CodecRegistry::AssetKind::Mesh &&
-			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
-			record.meshDecoder == decoder)
+		if (record->assetKind == CodecRegistry::AssetKind::Mesh &&
+			(record->capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			record->meshDecoder == decoder)
 		{
-			return &record;
+			return &(*record);
 		}
 	}
 
@@ -750,13 +753,13 @@ AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageEncoderRecord(AssetF
 		return nullptr;
 	}
 
-	for (const CodecRecord& record : records)
+	for (auto record = records.rbegin(); record != records.rend(); ++record)
 	{
-		if (record.assetKind == CodecRegistry::AssetKind::Image &&
-			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Encode)) != 0 &&
-			record.format == format)
+		if (record->assetKind == CodecRegistry::AssetKind::Image &&
+			(record->capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Encode)) != 0 &&
+			record->format == format)
 		{
-			return &record;
+			return &(*record);
 		}
 	}
 

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -10,6 +10,9 @@
 #include <limits>
 #include <new>
 #include <atomic>
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <cstdint>
 #include <system_error>
 #include <utility>
@@ -78,6 +81,77 @@ namespace
 		generation = (generation + 1u) & static_cast<uint32_t>(GENERATION_MASK);
 		return generation == 0 ? INITIAL_BLOB_GENERATION : generation;
 	}
+
+	std::filesystem::path NormalizeExtension(const std::filesystem::path& extension)
+	{
+		std::string normalizedExtension = extension.string();
+		std::transform(
+			normalizedExtension.begin(),
+			normalizedExtension.end(),
+			normalizedExtension.begin(),
+			[](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+
+		return std::filesystem::path(normalizedExtension);
+	}
+
+	bool ExtensionMatches(
+		const std::vector<std::filesystem::path>& supportedExtensions,
+		const std::filesystem::path& extension)
+	{
+		const std::filesystem::path normalizedExtension = NormalizeExtension(extension);
+		return std::find(supportedExtensions.begin(), supportedExtensions.end(), normalizedExtension) != supportedExtensions.end();
+	}
+
+	AssetSuite::AssetFormat FormatForImageDecoder(AssetSuite::ImageDecoders decoder) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::ImageDecoders::BMP:
+			return AssetSuite::AssetFormat::BMP;
+		case AssetSuite::ImageDecoders::PNG:
+			return AssetSuite::AssetFormat::PNG;
+		default:
+			return AssetSuite::AssetFormat::Unknown;
+		}
+	}
+
+	std::vector<std::filesystem::path> ExtensionsForImageDecoder(AssetSuite::ImageDecoders decoder)
+	{
+		switch (decoder)
+		{
+		case AssetSuite::ImageDecoders::BMP:
+			return { ".bmp" };
+		case AssetSuite::ImageDecoders::PNG:
+			return { ".png" };
+		default:
+			return {};
+		}
+	}
+
+	AssetSuite::AssetFormat FormatForMeshDecoder(AssetSuite::MeshDecoders decoder) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::MeshDecoders::WAVEFRONT:
+			return AssetSuite::AssetFormat::WavefrontObj;
+		default:
+			return AssetSuite::AssetFormat::Unknown;
+		}
+	}
+
+	std::vector<std::filesystem::path> ExtensionsForMeshDecoder(AssetSuite::MeshDecoders decoder)
+	{
+		switch (decoder)
+		{
+		case AssetSuite::MeshDecoders::WAVEFRONT:
+			return { ".obj" };
+		default:
+			return {};
+		}
+	}
 }
 
 AssetSuite::Internal::RuntimeState::RuntimeState()
@@ -99,7 +173,7 @@ AssetSuite::Internal::RuntimeState::CodecStorage::CodecStorage()
 
 AssetSuite::Internal::RuntimeState::CodecStorage::~CodecStorage() = default;
 
-void AssetSuite::Internal::RuntimeState::CodecStorage::RegisterWith(CodecRegistry& registry) noexcept
+void AssetSuite::Internal::RuntimeState::CodecStorage::RegisterWith(CodecRegistry& registry)
 {
 	registry.RegisterImageDecoder(ImageDecoders::BMP, *bmpDecoder);
 	registry.RegisterImageDecoder(ImageDecoders::PNG, *pngDecoder);
@@ -338,7 +412,7 @@ size_t AssetSuite::Internal::RuntimeState::BlobStorage::SlotCapacity() const noe
 
 bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(
 	ImageDecoders decoder,
-	ImageDecoder& implementation) noexcept
+	ImageDecoder& implementation)
 {
 	if (decoder == ImageDecoders::Auto || decoder == ImageDecoders::MaxDecoders)
 	{
@@ -346,12 +420,25 @@ bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(
 	}
 
 	imageDecoders[static_cast<size_t>(decoder)] = &implementation;
+	records.push_back(
+		{
+			CodecRegistry::AssetKind::Image,
+			static_cast<uint32_t>(CodecRegistry::Capability::Decode),
+			FormatForImageDecoder(decoder),
+			decoder,
+			MeshDecoders::Auto,
+			ExtensionsForImageDecoder(decoder),
+			nullptr,
+			&implementation,
+			nullptr,
+			nullptr
+		});
 	return true;
 }
 
 bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterMeshDecoder(
 	MeshDecoders decoder,
-	MeshDecoder& implementation) noexcept
+	MeshDecoder& implementation)
 {
 	if (decoder == MeshDecoders::Auto || decoder == MeshDecoders::MaxDecoders)
 	{
@@ -359,6 +446,19 @@ bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterMeshDecoder(
 	}
 
 	meshDecoders[static_cast<size_t>(decoder)] = &implementation;
+	records.push_back(
+		{
+			CodecRegistry::AssetKind::Mesh,
+			static_cast<uint32_t>(CodecRegistry::Capability::Decode),
+			FormatForMeshDecoder(decoder),
+			ImageDecoders::Auto,
+			decoder,
+			ExtensionsForMeshDecoder(decoder),
+			nullptr,
+			nullptr,
+			&implementation,
+			nullptr
+		});
 	return true;
 }
 
@@ -370,7 +470,8 @@ AssetSuite::ImageDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::Fin
 		return nullptr;
 	}
 
-	return imageDecoders[static_cast<size_t>(decoder)];
+	const CodecRecord* record = FindImageDecoderRecord(decoder);
+	return record ? record->imageDecoderImplementation : nullptr;
 }
 
 AssetSuite::MeshDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::FindMeshDecoder(
@@ -381,20 +482,22 @@ AssetSuite::MeshDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::Find
 		return nullptr;
 	}
 
-	return meshDecoders[static_cast<size_t>(decoder)];
+	const CodecRecord* record = FindMeshDecoderRecord(decoder);
+	return record ? record->meshDecoderImplementation : nullptr;
 }
 
 AssetSuite::ImageDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::ResolveImageDecoder(
 	const std::filesystem::path& extension) const noexcept
 {
-	if (extension.compare(".bmp") == 0)
+	const std::filesystem::path normalizedExtension = NormalizeExtension(extension);
+	for (const CodecRecord& record : records)
 	{
-		return ImageDecoders::BMP;
-	}
-
-	if (extension.compare(".png") == 0)
-	{
-		return ImageDecoders::PNG;
+		if (record.assetKind == CodecRegistry::AssetKind::Image &&
+			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			ExtensionMatches(record.extensions, normalizedExtension))
+		{
+			return record.imageDecoder;
+		}
 	}
 
 	return ImageDecoders::Auto;
@@ -403,10 +506,64 @@ AssetSuite::ImageDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::Res
 AssetSuite::MeshDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::ResolveMeshDecoder(
 	const std::filesystem::path& extension) const noexcept
 {
-	if (extension.compare(".obj") == 0)
+	const std::filesystem::path normalizedExtension = NormalizeExtension(extension);
+	for (const CodecRecord& record : records)
 	{
-		return MeshDecoders::WAVEFRONT;
+		if (record.assetKind == CodecRegistry::AssetKind::Mesh &&
+			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			ExtensionMatches(record.extensions, normalizedExtension))
+		{
+			return record.meshDecoder;
+		}
 	}
 
 	return MeshDecoders::Auto;
+}
+
+const std::vector<AssetSuite::Internal::RuntimeState::CodecRegistry::CodecRecord>&
+AssetSuite::Internal::RuntimeState::CodecRegistry::Records() const noexcept
+{
+	return records;
+}
+
+const AssetSuite::Internal::RuntimeState::CodecRegistry::CodecRecord*
+AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageDecoderRecord(ImageDecoders decoder) const noexcept
+{
+	if (decoder == ImageDecoders::Auto || decoder == ImageDecoders::MaxDecoders)
+	{
+		return nullptr;
+	}
+
+	for (const CodecRecord& record : records)
+	{
+		if (record.assetKind == CodecRegistry::AssetKind::Image &&
+			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			record.imageDecoder == decoder)
+		{
+			return &record;
+		}
+	}
+
+	return nullptr;
+}
+
+const AssetSuite::Internal::RuntimeState::CodecRegistry::CodecRecord*
+AssetSuite::Internal::RuntimeState::CodecRegistry::FindMeshDecoderRecord(MeshDecoders decoder) const noexcept
+{
+	if (decoder == MeshDecoders::Auto || decoder == MeshDecoders::MaxDecoders)
+	{
+		return nullptr;
+	}
+
+	for (const CodecRecord& record : records)
+	{
+		if (record.assetKind == CodecRegistry::AssetKind::Mesh &&
+			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			record.meshDecoder == decoder)
+		{
+			return &record;
+		}
+	}
+
+	return nullptr;
 }

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cstring>
 #include <cstdint>
 #include <system_error>
 #include <utility>
@@ -105,6 +106,71 @@ namespace
 		return std::find(supportedExtensions.begin(), supportedExtensions.end(), normalizedExtension) != supportedExtensions.end();
 	}
 
+	bool HasBmpSignature(const uint8_t* data, size_t size) noexcept
+	{
+		return data && size >= 2 && data[0] == 'B' && data[1] == 'M';
+	}
+
+	bool HasPngSignature(const uint8_t* data, size_t size) noexcept
+	{
+		constexpr uint8_t PNG_SIGNATURE[] = { 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' };
+		return data && size >= sizeof(PNG_SIGNATURE) && std::memcmp(data, PNG_SIGNATURE, sizeof(PNG_SIGNATURE)) == 0;
+	}
+
+	bool StartsWithToken(const char* line, size_t lineLength, const char* token) noexcept
+	{
+		const size_t tokenLength = std::strlen(token);
+		return lineLength >= tokenLength &&
+			std::memcmp(line, token, tokenLength) == 0 &&
+			(lineLength == tokenLength || std::isspace(static_cast<unsigned char>(line[tokenLength])) != 0);
+	}
+
+	bool HasWavefrontObjContent(const uint8_t* data, size_t size) noexcept
+	{
+		if (!data || size == 0)
+		{
+			return false;
+		}
+
+		const char* text = reinterpret_cast<const char*>(data);
+		size_t offset = 0;
+		while (offset < size)
+		{
+			while (offset < size && (text[offset] == ' ' || text[offset] == '\t' || text[offset] == '\r' || text[offset] == '\n'))
+			{
+				++offset;
+			}
+
+			if (offset >= size || text[offset] == '\0')
+			{
+				break;
+			}
+
+			const size_t lineStart = offset;
+			while (offset < size && text[offset] != '\r' && text[offset] != '\n' && text[offset] != '\0')
+			{
+				++offset;
+			}
+
+			const size_t lineLength = offset - lineStart;
+			const char* line = text + lineStart;
+			if (lineLength > 0 &&
+				(StartsWithToken(line, lineLength, "v") ||
+					StartsWithToken(line, lineLength, "vn") ||
+					StartsWithToken(line, lineLength, "vt") ||
+					StartsWithToken(line, lineLength, "f") ||
+					StartsWithToken(line, lineLength, "o") ||
+					StartsWithToken(line, lineLength, "g") ||
+					StartsWithToken(line, lineLength, "mtllib") ||
+					StartsWithToken(line, lineLength, "usemtl")))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	AssetSuite::AssetFormat FormatForImageDecoder(AssetSuite::ImageDecoders decoder) noexcept
 	{
 		switch (decoder)
@@ -131,6 +197,20 @@ namespace
 		}
 	}
 
+	AssetSuite::Internal::RuntimeState::CodecRegistry::ProbeCallback ProbeForImageDecoder(
+		AssetSuite::ImageDecoders decoder) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::ImageDecoders::BMP:
+			return &HasBmpSignature;
+		case AssetSuite::ImageDecoders::PNG:
+			return &HasPngSignature;
+		default:
+			return nullptr;
+		}
+	}
+
 	AssetSuite::AssetFormat FormatForMeshDecoder(AssetSuite::MeshDecoders decoder) noexcept
 	{
 		switch (decoder)
@@ -150,6 +230,18 @@ namespace
 			return { ".obj" };
 		default:
 			return {};
+		}
+	}
+
+	AssetSuite::Internal::RuntimeState::CodecRegistry::ProbeCallback ProbeForMeshDecoder(
+		AssetSuite::MeshDecoders decoder) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::MeshDecoders::WAVEFRONT:
+			return &HasWavefrontObjContent;
+		default:
+			return nullptr;
 		}
 	}
 
@@ -440,7 +532,7 @@ bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(
 			decoder,
 			MeshDecoders::Auto,
 			ExtensionsForImageDecoder(decoder),
-			nullptr,
+			ProbeForImageDecoder(decoder),
 			&implementation,
 			nullptr,
 			nullptr
@@ -466,7 +558,7 @@ bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterMeshDecoder(
 			ImageDecoders::Auto,
 			decoder,
 			ExtensionsForMeshDecoder(decoder),
-			nullptr,
+			ProbeForMeshDecoder(decoder),
 			nullptr,
 			&implementation,
 			nullptr
@@ -562,6 +654,44 @@ AssetSuite::MeshDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::Reso
 	}
 
 	return MeshDecoders::Auto;
+}
+
+AssetSuite::ImageDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::ProbeImageDecoder(
+	const std::filesystem::path& extension,
+	const uint8_t* data,
+	size_t size) const noexcept
+{
+	for (const CodecRecord& record : records)
+	{
+		if (record.assetKind == CodecRegistry::AssetKind::Image &&
+			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			record.probe &&
+			record.probe(data, size))
+		{
+			return record.imageDecoder;
+		}
+	}
+
+	return ResolveImageDecoder(extension);
+}
+
+AssetSuite::MeshDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::ProbeMeshDecoder(
+	const std::filesystem::path& extension,
+	const uint8_t* data,
+	size_t size) const noexcept
+{
+	for (const CodecRecord& record : records)
+	{
+		if (record.assetKind == CodecRegistry::AssetKind::Mesh &&
+			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
+			record.probe &&
+			record.probe(data, size))
+		{
+			return record.meshDecoder;
+		}
+	}
+
+	return ResolveMeshDecoder(extension);
 }
 
 const std::vector<AssetSuite::Internal::RuntimeState::CodecRegistry::CodecRecord>&

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -152,6 +152,17 @@ namespace
 			return {};
 		}
 	}
+
+	std::vector<std::filesystem::path> ExtensionsForImageEncoder(AssetSuite::AssetFormat format)
+	{
+		switch (format)
+		{
+		case AssetSuite::AssetFormat::PPM:
+			return { ".ppm" };
+		default:
+			return {};
+		}
+	}
 }
 
 AssetSuite::Internal::RuntimeState::RuntimeState()
@@ -178,6 +189,7 @@ void AssetSuite::Internal::RuntimeState::CodecStorage::RegisterWith(CodecRegistr
 	registry.RegisterImageDecoder(ImageDecoders::BMP, *bmpDecoder);
 	registry.RegisterImageDecoder(ImageDecoders::PNG, *pngDecoder);
 	registry.RegisterMeshDecoder(MeshDecoders::WAVEFRONT, *modelLoader);
+	registry.RegisterImageEncoder(AssetFormat::PPM, *ppmEncoder);
 }
 
 void* AssetSuite::Internal::RuntimeState::AllocatorPolicy::Allocate(size_t size, size_t alignment)
@@ -462,6 +474,31 @@ bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterMeshDecoder(
 	return true;
 }
 
+bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageEncoder(
+	AssetFormat format,
+	ImageEncoder& implementation)
+{
+	if (format == AssetFormat::Unknown)
+	{
+		return false;
+	}
+
+	records.push_back(
+		{
+			CodecRegistry::AssetKind::Image,
+			static_cast<uint32_t>(CodecRegistry::Capability::Encode),
+			format,
+			ImageDecoders::Auto,
+			MeshDecoders::Auto,
+			ExtensionsForImageEncoder(format),
+			nullptr,
+			nullptr,
+			nullptr,
+			&implementation
+		});
+	return true;
+}
+
 AssetSuite::ImageDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageDecoder(
 	ImageDecoders decoder) const noexcept
 {
@@ -484,6 +521,13 @@ AssetSuite::MeshDecoder* AssetSuite::Internal::RuntimeState::CodecRegistry::Find
 
 	const CodecRecord* record = FindMeshDecoderRecord(decoder);
 	return record ? record->meshDecoderImplementation : nullptr;
+}
+
+AssetSuite::ImageEncoder* AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageEncoder(
+	AssetFormat format) const noexcept
+{
+	const CodecRecord* record = FindImageEncoderRecord(format);
+	return record ? record->imageEncoderImplementation : nullptr;
 }
 
 AssetSuite::ImageDecoders AssetSuite::Internal::RuntimeState::CodecRegistry::ResolveImageDecoder(
@@ -560,6 +604,27 @@ AssetSuite::Internal::RuntimeState::CodecRegistry::FindMeshDecoderRecord(MeshDec
 		if (record.assetKind == CodecRegistry::AssetKind::Mesh &&
 			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Decode)) != 0 &&
 			record.meshDecoder == decoder)
+		{
+			return &record;
+		}
+	}
+
+	return nullptr;
+}
+
+const AssetSuite::Internal::RuntimeState::CodecRegistry::CodecRecord*
+AssetSuite::Internal::RuntimeState::CodecRegistry::FindImageEncoderRecord(AssetFormat format) const noexcept
+{
+	if (format == AssetFormat::Unknown)
+	{
+		return nullptr;
+	}
+
+	for (const CodecRecord& record : records)
+	{
+		if (record.assetKind == CodecRegistry::AssetKind::Image &&
+			(record.capabilities & static_cast<uint32_t>(CodecRegistry::Capability::Encode)) != 0 &&
+			record.format == format)
 		{
 			return &record;
 		}

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -120,8 +120,10 @@ namespace AssetSuite::Internal
 
 			bool RegisterImageDecoder(ImageDecoders decoder, ImageDecoder& implementation);
 			bool RegisterMeshDecoder(MeshDecoders decoder, MeshDecoder& implementation);
+			bool RegisterImageEncoder(AssetFormat format, ImageEncoder& implementation);
 			ImageDecoder* FindImageDecoder(ImageDecoders decoder) const noexcept;
 			MeshDecoder* FindMeshDecoder(MeshDecoders decoder) const noexcept;
+			ImageEncoder* FindImageEncoder(AssetFormat format) const noexcept;
 			ImageDecoders ResolveImageDecoder(const std::filesystem::path& extension) const noexcept;
 			MeshDecoders ResolveMeshDecoder(const std::filesystem::path& extension) const noexcept;
 			const std::vector<CodecRecord>& Records() const noexcept;
@@ -129,6 +131,7 @@ namespace AssetSuite::Internal
 		private:
 			const CodecRecord* FindImageDecoderRecord(ImageDecoders decoder) const noexcept;
 			const CodecRecord* FindMeshDecoderRecord(MeshDecoders decoder) const noexcept;
+			const CodecRecord* FindImageEncoderRecord(AssetFormat format) const noexcept;
 
 			std::array<ImageDecoder*, static_cast<size_t>(ImageDecoders::MaxDecoders)> imageDecoders = {};
 			std::array<MeshDecoder*, static_cast<size_t>(MeshDecoders::MaxDecoders)> meshDecoders = {};

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -126,6 +126,8 @@ namespace AssetSuite::Internal
 			ImageEncoder* FindImageEncoder(AssetFormat format) const noexcept;
 			ImageDecoders ResolveImageDecoder(const std::filesystem::path& extension) const noexcept;
 			MeshDecoders ResolveMeshDecoder(const std::filesystem::path& extension) const noexcept;
+			ImageDecoders ProbeImageDecoder(const std::filesystem::path& extension, const uint8_t* data, size_t size) const noexcept;
+			MeshDecoders ProbeMeshDecoder(const std::filesystem::path& extension, const uint8_t* data, size_t size) const noexcept;
 			const std::vector<CodecRecord>& Records() const noexcept;
 
 		private:

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -13,6 +13,7 @@
 
 #include "../common/ImageDescriptor.h"
 #include "../common/ImageDecoder.h"
+#include "../common/ImageEncoder.h"
 #include "../common/MeshDecoder.h"
 #include "../common/AssetSuite.h"
 
@@ -89,16 +90,49 @@ namespace AssetSuite::Internal
 
 		struct CodecRegistry
 		{
-			bool RegisterImageDecoder(ImageDecoders decoder, ImageDecoder& implementation) noexcept;
-			bool RegisterMeshDecoder(MeshDecoders decoder, MeshDecoder& implementation) noexcept;
+			enum class AssetKind
+			{
+				Image,
+				Mesh
+			};
+
+			enum class Capability : uint32_t
+			{
+				Decode = 1u << 0,
+				Encode = 1u << 1
+			};
+
+			using ProbeCallback = bool (*)(const uint8_t* data, size_t size) noexcept;
+
+			struct CodecRecord
+			{
+				AssetKind assetKind = AssetKind::Image;
+				uint32_t capabilities = 0;
+				AssetFormat format = AssetFormat::Unknown;
+				ImageDecoders imageDecoder = ImageDecoders::Auto;
+				MeshDecoders meshDecoder = MeshDecoders::Auto;
+				std::vector<std::filesystem::path> extensions;
+				ProbeCallback probe = nullptr;
+				ImageDecoder* imageDecoderImplementation = nullptr;
+				MeshDecoder* meshDecoderImplementation = nullptr;
+				ImageEncoder* imageEncoderImplementation = nullptr;
+			};
+
+			bool RegisterImageDecoder(ImageDecoders decoder, ImageDecoder& implementation);
+			bool RegisterMeshDecoder(MeshDecoders decoder, MeshDecoder& implementation);
 			ImageDecoder* FindImageDecoder(ImageDecoders decoder) const noexcept;
 			MeshDecoder* FindMeshDecoder(MeshDecoders decoder) const noexcept;
 			ImageDecoders ResolveImageDecoder(const std::filesystem::path& extension) const noexcept;
 			MeshDecoders ResolveMeshDecoder(const std::filesystem::path& extension) const noexcept;
+			const std::vector<CodecRecord>& Records() const noexcept;
 
 		private:
+			const CodecRecord* FindImageDecoderRecord(ImageDecoders decoder) const noexcept;
+			const CodecRecord* FindMeshDecoderRecord(MeshDecoders decoder) const noexcept;
+
 			std::array<ImageDecoder*, static_cast<size_t>(ImageDecoders::MaxDecoders)> imageDecoders = {};
 			std::array<MeshDecoder*, static_cast<size_t>(MeshDecoders::MaxDecoders)> meshDecoders = {};
+			std::vector<CodecRecord> records;
 		};
 
 		struct CodecStorage
@@ -115,7 +149,7 @@ namespace AssetSuite::Internal
 			std::unique_ptr<PpmEncoder> ppmEncoder;
 			std::unique_ptr<BypassEncoder> bypassEncoder;
 
-			void RegisterWith(CodecRegistry& registry) noexcept;
+			void RegisterWith(CodecRegistry& registry);
 		};
 
 		struct FileInfo

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -26,6 +26,8 @@ Legacy `Manager` remains as a compatibility facade for existing tests and demo c
 
 Only concrete codec identifiers may be registered or queried. Sentinel values such as `Auto` and `MaxDecoders` are resolved or rejected before lookup.
 
+The built-in registry treats `PpmEncoder` as the currently supported image encoder path. Format probing should prefer recognized signatures or content markers over filename extensions, with extensions used as a fallback when bytes are unavailable or inconclusive. If an extension and signature disagree, the recognized byte signature is authoritative.
+
 ## SDK Boundary
 
 Runtime headers under `source/runtime` are private implementation files. They must not be installed with the public SDK headers and must not be included from `include/AssetSuite`.

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -676,6 +676,94 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(context);
 		}
 
+		TEST_METHOD(RuntimeCodecRegistryResolvesBuiltInDecodersByExtension)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::BMP == registry.ResolveImageDecoder(".bmp"));
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::PNG == registry.ResolveImageDecoder(".PNG"));
+			Assert::AreEqual(true, AssetSuite::MeshDecoders::WAVEFRONT == registry.ResolveMeshDecoder(".obj"));
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::Auto == registry.ResolveImageDecoder(".asset"));
+			Assert::AreEqual(true, AssetSuite::MeshDecoders::Auto == registry.ResolveMeshDecoder(".asset"));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryProbesImageDecodersBySignature)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+			const std::vector<uint8_t> bmpBytes = { 'B', 'M', 0x00, 0x00 };
+			const std::vector<uint8_t> pngBytes = { 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' };
+
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::BMP == registry.ProbeImageDecoder(".asset", bmpBytes.data(), bmpBytes.size()));
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::PNG == registry.ProbeImageDecoder(".asset", pngBytes.data(), pngBytes.size()));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryPrefersImageSignatureOverExtension)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+			const std::vector<uint8_t> bmpBytes = { 'B', 'M', 0x00, 0x00 };
+			const std::vector<uint8_t> pngBytes = { 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n' };
+
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::BMP == registry.ProbeImageDecoder(".png", bmpBytes.data(), bmpBytes.size()));
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::PNG == registry.ProbeImageDecoder(".bmp", pngBytes.data(), pngBytes.size()));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryProbesObjContent)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+			const std::vector<uint8_t> objBytes = { '#', ' ', 'm', 'e', 's', 'h', '\n', 'v', ' ', '0', ' ', '1', ' ', '2', '\n' };
+
+			Assert::AreEqual(true, AssetSuite::MeshDecoders::WAVEFRONT == registry.ProbeMeshDecoder(".asset", objBytes.data(), objBytes.size()));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryRejectsUnknownProbeBytes)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+			const std::vector<uint8_t> unknownBytes = { 0x00, 0x01, 0x02 };
+
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::Auto == registry.ProbeImageDecoder(".asset", unknownBytes.data(), unknownBytes.size()));
+			Assert::AreEqual(true, AssetSuite::MeshDecoders::Auto == registry.ProbeMeshDecoder(".asset", unknownBytes.data(), unknownBytes.size()));
+			Assert::AreEqual(true, AssetSuite::ImageDecoders::Auto == registry.ProbeImageDecoder({}, nullptr, 0));
+			Assert::AreEqual(true, AssetSuite::MeshDecoders::Auto == registry.ProbeMeshDecoder({}, nullptr, 0));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryRegistersPpmImageEncoder)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+
+			Assert::IsNotNull(registry.FindImageEncoder(AssetSuite::AssetFormat::PPM));
+			Assert::IsNull(registry.FindImageEncoder(AssetSuite::AssetFormat::Unknown));
+
+			DestroyContextForCleanup(context);
+		}
+
 	private:
 		struct LogCapture
 		{

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -83,6 +83,33 @@ namespace
 
 		return currentDirectory;
 	}
+
+	class TestImageDecoder final : public AssetSuite::ImageDecoder
+	{
+	public:
+		bool Decode(std::vector<BYTE>& output, BYTE* buffer, AssetSuite::ImageDescriptor& descriptor) override
+		{
+			return true;
+		}
+	};
+
+	class TestMeshDecoder final : public AssetSuite::MeshDecoder
+	{
+	public:
+		bool Decode(std::vector<BYTE>& output, BYTE* buffer, AssetSuite::MeshDescriptor& descriptor) override
+		{
+			return true;
+		}
+	};
+
+	class TestImageEncoder final : public AssetSuite::ImageEncoder
+	{
+	public:
+		std::vector<BYTE> Encode(const std::vector<BYTE>& buffer, const AssetSuite::ImageDescriptor& descriptor) override
+		{
+			return buffer;
+		}
+	};
 }
 
 namespace GeneralUnitTests
@@ -728,9 +755,26 @@ namespace GeneralUnitTests
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
 
 			auto& registry = context->Runtime().CodecRegistry();
-			const std::vector<uint8_t> objBytes = { '#', ' ', 'm', 'e', 's', 'h', '\n', 'v', ' ', '0', ' ', '1', ' ', '2', '\n' };
+			const std::vector<uint8_t> objBytes = {
+				'#', ' ', 'm', 'e', 's', 'h', '\n',
+				'v', ' ', '0', ' ', '1', ' ', '2', '\n',
+				'f', ' ', '1', ' ', '1', ' ', '1', '\n'
+			};
 
 			Assert::AreEqual(true, AssetSuite::MeshDecoders::WAVEFRONT == registry.ProbeMeshDecoder(".asset", objBytes.data(), objBytes.size()));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryRejectsObjLabelsWithoutGeometry)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+			const std::vector<uint8_t> objLabelBytes = { 'o', ' ', 'n', 'a', 'm', 'e', '\n', 'g', ' ', 'g', 'r', 'o', 'u', 'p', '\n' };
+
+			Assert::AreEqual(true, AssetSuite::MeshDecoders::Auto == registry.ProbeMeshDecoder(".asset", objLabelBytes.data(), objLabelBytes.size()));
 
 			DestroyContextForCleanup(context);
 		}
@@ -760,6 +804,27 @@ namespace GeneralUnitTests
 
 			Assert::IsNotNull(registry.FindImageEncoder(AssetSuite::AssetFormat::PPM));
 			Assert::IsNull(registry.FindImageEncoder(AssetSuite::AssetFormat::Unknown));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeCodecRegistryUsesLatestRegisteredImplementations)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			auto& registry = context->Runtime().CodecRegistry();
+			TestImageDecoder imageDecoder;
+			TestMeshDecoder meshDecoder;
+			TestImageEncoder imageEncoder;
+
+			Assert::IsTrue(registry.RegisterImageDecoder(AssetSuite::ImageDecoders::BMP, imageDecoder));
+			Assert::IsTrue(registry.RegisterMeshDecoder(AssetSuite::MeshDecoders::WAVEFRONT, meshDecoder));
+			Assert::IsTrue(registry.RegisterImageEncoder(AssetSuite::AssetFormat::PPM, imageEncoder));
+
+			Assert::IsTrue(registry.FindImageDecoder(AssetSuite::ImageDecoders::BMP) == &imageDecoder);
+			Assert::IsTrue(registry.FindMeshDecoder(AssetSuite::MeshDecoders::WAVEFRONT) == &meshDecoder);
+			Assert::IsTrue(registry.FindImageEncoder(AssetSuite::AssetFormat::PPM) == &imageEncoder);
 
 			DestroyContextForCleanup(context);
 		}

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -801,16 +801,13 @@ namespace GeneralUnitTests
 	{
 	public:
 
-		TEST_METHOD(FileExtensionNotSupported)
+		TEST_METHOD(ImageUnsupportedExtensionUsesRecognizedSignature)
 		{
-			// In this test we don't need real data
-			std::vector<BYTE> output;
 			AssetSuite::Manager manager;
 
-			// This file needs to exist
 			manager.ImageLoad("test_file.xyz");
 			auto error = manager.ImageDecode(AssetSuite::ImageDecoders::Auto);
-			Assert::AreEqual(true, AssetSuite::ErrorCode::FileTypeNotSupported == error);
+			Assert::AreEqual(true, AssetSuite::ErrorCode::OK == error);
 		}
 
 		TEST_METHOD(ImageOpeningNonExistingFile)


### PR DESCRIPTION
## Summary

- Refactors the private runtime codec registry into richer codec records carrying asset kind, capability, public format, extensions, probe callbacks, and implementation pointers.
- Registers built-in BMP/PNG image decoders, Wavefront OBJ mesh decoder, and the current PPM image encoder path through the internal registry.
- Adds BMP/PNG signature probing, lightweight OBJ content probing, signature-over-extension precedence, and focused unit coverage.
- Routes legacy `Manager` auto decode paths through the registry probe path while keeping the public SDK headers unchanged.

## Validation

- Added unit tests in `unit_tests/GeneralUnitTests.cpp` covering extension resolution, signature/content probing, mismatched extension/signature behavior, unknown data, and PPM encoder registration.
- Confirmed the worktree is clean and public installed headers under `include/AssetSuite` were not changed.
- Attempted local Windows Debug MSBuild validation, but this Codex shell exposes duplicate `PATH`/`Path` environment variables. Visual Studio's C++ task fails before compilation with `Item has already been added. Key in dictionary: 'Path' Key being added: 'PATH'`, so full Debug/Release build and test execution should be rerun from a normal Developer PowerShell or Visual Studio environment.

Closes #43.