### PR TITLE
[codex] Implement decode routing from file and blob entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,19 @@ other operations on the context.
 ## Decode Error Contract
 
 Image and mesh decode entry points use shared runtime probing before invoking a
-codec. If no registered decoder can be selected for the supplied bytes and
+codec. If no registered codec can be selected for the supplied bytes and
 source metadata, the public result is `AssetSuite::Result::ErrorUnsupportedFormat`.
 
-Once a decoder is selected, malformed source bytes are reported as
+Once a codec is selected, malformed source bytes are reported as
 `AssetSuite::Result::ErrorMalformedData` when the runtime can classify the
-failure as input corruption. Other selected-decoder failures are reported as
-`AssetSuite::Result::ErrorDecodeFailed`.
+failure as input corruption.
 
 Blob decode entry points preserve the caller's source `AssetSuite::BlobHandle`.
 File decode entry points use the same runtime route after loading file bytes,
 but their temporary source blob is not exposed or retained after the call.
+Decoded image and mesh handles can be inspected through their descriptor APIs
+and must be released with `AssetSuite::ReleaseImage` or
+`AssetSuite::ReleaseMesh`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Once a decoder is selected, malformed source bytes are reported as
 failure as input corruption. Other selected-decoder failures are reported as
 `AssetSuite::Result::ErrorDecodeFailed`.
 
+Blob decode entry points preserve the caller's source `AssetSuite::BlobHandle`.
+File decode entry points use the same runtime route after loading file bytes,
+but their temporary source blob is not exposed or retained after the call.
+
 ## Usage
 
 The current 2.0 public SDK headers expose the stable type, version, and context

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The public headers are provided under `include/AssetSuite` and are installed und
 - `AssetSuite::Result` and `AssetSuite::Version`
 - `AssetSuite::GetVersion` and `AssetSuite::GetResultString`
 - `AssetSuite::LogLevel`, `AssetSuite::LoggingCallback`, and `AssetSuite::SetLoggingCallback`
+- file and blob decode entry points for image and mesh assets
 - opaque handle types such as `AssetSuite::ContextHandle`, `AssetSuite::BlobHandle`, `AssetSuite::ImageHandle`, and `AssetSuite::MeshHandle`
 - plain descriptor structs such as `AssetSuite::ContextDesc`, `AssetSuite::BlobDesc`, `AssetSuite::ImageDesc`, and `AssetSuite::MeshDesc`
 - SDK enums such as `AssetSuite::AssetFormat`, `AssetSuite::PixelFormat`, and `AssetSuite::MeshAttributeFlags`
@@ -64,6 +65,17 @@ of `userData`, does not interpret it, and does not manage its lifetime. The
 message pointer is valid only for the duration of the callback invocation.
 Callback invocation follows the same external synchronization expectations as
 other operations on the context.
+
+## Decode Error Contract
+
+Image and mesh decode entry points use shared runtime probing before invoking a
+codec. If no registered decoder can be selected for the supplied bytes and
+source metadata, the public result is `AssetSuite::Result::ErrorUnsupportedFormat`.
+
+Once a decoder is selected, malformed source bytes are reported as
+`AssetSuite::Result::ErrorMalformedData` when the runtime can classify the
+failure as input corruption. Other selected-decoder failures are reported as
+`AssetSuite::Result::ErrorDecodeFailed`.
 
 ## Usage
 

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -64,9 +64,9 @@ namespace AssetSuite
 	// invalid blob handle, including a handle from another context, returns
 	// Result::ErrorInvalidHandle. Passing a null outImage or non-null
 	// *outImage returns Result::ErrorInvalidArgument. Inputs that cannot be
-	// routed to a registered image decoder return
+	// routed to a registered image codec return
 	// Result::ErrorUnsupportedFormat. Recognized but malformed image bytes
-	// return Result::ErrorMalformedData where the selected decoder can
+	// return Result::ErrorMalformedData where the selected codec can
 	// distinguish malformed input, otherwise Result::ErrorDecodeFailed.
 	ASSET_SUITE_API Result DecodeImage(ContextHandle context, BlobHandle blob, ImageHandle* outImage);
 

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -56,9 +56,9 @@ namespace AssetSuite
 	ASSET_SUITE_API Result LoadFile(ContextHandle context, const char* filePath, BlobHandle* outBlob);
 
 	// Decodes a runtime-owned blob into a runtime-owned image. outImage must
-	// point to a null handle and receives ownership of the created image handle
-	// on success. The source blob remains owned by the context and is not
-	// released by this call.
+	// point to a null handle and receives the created image handle on success.
+	// The source blob remains owned by the context and is not released by this
+	// call.
 	//
 	// Passing a null context returns Result::ErrorInvalidContext. Passing an
 	// invalid blob handle, including a handle from another context, returns
@@ -67,7 +67,7 @@ namespace AssetSuite
 	// routed to a registered image codec return
 	// Result::ErrorUnsupportedFormat. Recognized but malformed image bytes
 	// return Result::ErrorMalformedData where the selected codec can
-	// distinguish malformed input, otherwise Result::ErrorDecodeFailed.
+	// distinguish malformed input.
 	ASSET_SUITE_API Result DecodeImage(ContextHandle context, BlobHandle blob, ImageHandle* outImage);
 
 	// Loads a file and decodes it into a runtime-owned image using the same
@@ -83,6 +83,27 @@ namespace AssetSuite
 	// runtime probing and codec invocation path as DecodeMesh. The temporary
 	// file bytes are owned only for the duration of this call.
 	ASSET_SUITE_API Result DecodeMeshFromFile(ContextHandle context, const char* filePath, MeshHandle* outMesh);
+
+	// Writes the descriptor for a runtime-owned image handle. Passing a null
+	// context returns Result::ErrorInvalidContext. Passing a null outDesc
+	// returns Result::ErrorInvalidArgument. Passing a null, stale, or
+	// foreign-context image handle returns Result::ErrorInvalidHandle.
+	ASSET_SUITE_API Result GetImageDesc(ContextHandle context, ImageHandle image, ImageDesc* outDesc);
+
+	// Writes the descriptor for a runtime-owned mesh handle. Validation and
+	// result mapping follow GetImageDesc.
+	ASSET_SUITE_API Result GetMeshDesc(ContextHandle context, MeshHandle mesh, MeshDesc* outDesc);
+
+	// Releases a runtime-owned image handle and sets the caller's handle to
+	// nullptr on success. Passing a null context returns
+	// Result::ErrorInvalidContext. Passing nullptr, a pointer to a null image
+	// handle, a stale handle, or a handle from another context returns
+	// Result::ErrorInvalidHandle.
+	ASSET_SUITE_API Result ReleaseImage(ContextHandle context, ImageHandle* image);
+
+	// Releases a runtime-owned mesh handle and sets the caller's handle to
+	// nullptr on success. Validation and result mapping follow ReleaseImage.
+	ASSET_SUITE_API Result ReleaseMesh(ContextHandle context, MeshHandle* mesh);
 
 	// Releases a runtime-owned blob and sets the caller's handle to nullptr on
 	// success. Memory and metadata behind the blob are invalid immediately

--- a/include/AssetSuite/AssetSuite.h
+++ b/include/AssetSuite/AssetSuite.h
@@ -55,6 +55,35 @@ namespace AssetSuite
 	// return Result::ErrorIoFailure.
 	ASSET_SUITE_API Result LoadFile(ContextHandle context, const char* filePath, BlobHandle* outBlob);
 
+	// Decodes a runtime-owned blob into a runtime-owned image. outImage must
+	// point to a null handle and receives ownership of the created image handle
+	// on success. The source blob remains owned by the context and is not
+	// released by this call.
+	//
+	// Passing a null context returns Result::ErrorInvalidContext. Passing an
+	// invalid blob handle, including a handle from another context, returns
+	// Result::ErrorInvalidHandle. Passing a null outImage or non-null
+	// *outImage returns Result::ErrorInvalidArgument. Inputs that cannot be
+	// routed to a registered image decoder return
+	// Result::ErrorUnsupportedFormat. Recognized but malformed image bytes
+	// return Result::ErrorMalformedData where the selected decoder can
+	// distinguish malformed input, otherwise Result::ErrorDecodeFailed.
+	ASSET_SUITE_API Result DecodeImage(ContextHandle context, BlobHandle blob, ImageHandle* outImage);
+
+	// Loads a file and decodes it into a runtime-owned image using the same
+	// runtime probing and codec invocation path as DecodeImage. The temporary
+	// file bytes are owned only for the duration of this call.
+	ASSET_SUITE_API Result DecodeImageFromFile(ContextHandle context, const char* filePath, ImageHandle* outImage);
+
+	// Decodes a runtime-owned blob into a runtime-owned mesh. Ownership,
+	// validation, probing, and error mapping follow DecodeImage.
+	ASSET_SUITE_API Result DecodeMesh(ContextHandle context, BlobHandle blob, MeshHandle* outMesh);
+
+	// Loads a file and decodes it into a runtime-owned mesh using the same
+	// runtime probing and codec invocation path as DecodeMesh. The temporary
+	// file bytes are owned only for the duration of this call.
+	ASSET_SUITE_API Result DecodeMeshFromFile(ContextHandle context, const char* filePath, MeshHandle* outMesh);
+
 	// Releases a runtime-owned blob and sets the caller's handle to nullptr on
 	// success. Memory and metadata behind the blob are invalid immediately
 	// after a successful release.

--- a/include/AssetSuite/AssetSuiteTypes.h
+++ b/include/AssetSuite/AssetSuiteTypes.h
@@ -20,6 +20,7 @@ namespace AssetSuite
 		ErrorInvalidContext = -7,
 		ErrorInvalidHandle = -8,
 		ErrorIoFailure = -9,
+		ErrorMalformedData = -10,
 		ErrorUnknown = -1000
 	};
 

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -327,6 +327,70 @@ AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const c
 	}
 }
 
+AssetSuite::Result AssetSuite::GetImageDesc(ContextHandle context, ImageHandle image, ImageDesc* outDesc)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!outDesc)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	const AssetSuiteImage_t* storedImage = context->Runtime().ImageStorage().Get(image);
+	if (!storedImage)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	*outDesc = storedImage->desc;
+	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::GetMeshDesc(ContextHandle context, MeshHandle mesh, MeshDesc* outDesc)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!outDesc)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	const AssetSuiteMesh_t* storedMesh = context->Runtime().MeshStorage().Get(mesh);
+	if (!storedMesh)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	*outDesc = storedMesh->desc;
+	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::ReleaseImage(ContextHandle context, ImageHandle* image)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	return context->Runtime().ImageStorage().Release(image);
+}
+
+AssetSuite::Result AssetSuite::ReleaseMesh(ContextHandle context, MeshHandle* mesh)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	return context->Runtime().MeshStorage().Release(mesh);
+}
+
 AssetSuite::Result AssetSuite::ReleaseBlob(ContextHandle context, BlobHandle* blob)
 {
 	if (!context)

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -402,7 +402,28 @@ AssetSuite::Result AssetSuite::DecodeImageFromFile(ContextHandle context, const 
 		return Result::ErrorInvalidArgument;
 	}
 
-	return Result::ErrorUnsupportedFormat;
+	std::vector<uint8_t> rawBytes;
+	const ErrorCode loadResult = LoadRuntimeFileToMemory(context->Runtime(), filePath, true, rawBytes);
+	const Result mappedResult = MapFileLoadResult(loadResult);
+	if (mappedResult != Result::Success)
+	{
+		context->Runtime().Diagnostics().Add(loadResult, "Failed to load image source file.");
+		return mappedResult;
+	}
+
+	try
+	{
+		Internal::Blob blob(std::move(rawBytes), Internal::MakeBlobSourceMetadata(filePath));
+		return DecodeImageBlob(context->Runtime(), blob, outImage);
+	}
+	catch (const std::bad_alloc&)
+	{
+		return Result::ErrorOutOfMemory;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
+	}
 }
 
 AssetSuite::Result AssetSuite::DecodeMesh(ContextHandle context, BlobHandle blob, MeshHandle* outMesh)
@@ -443,7 +464,28 @@ AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const c
 		return Result::ErrorInvalidArgument;
 	}
 
-	return Result::ErrorUnsupportedFormat;
+	std::vector<uint8_t> rawBytes;
+	const ErrorCode loadResult = LoadRuntimeFileToMemory(context->Runtime(), filePath, true, rawBytes);
+	const Result mappedResult = MapFileLoadResult(loadResult);
+	if (mappedResult != Result::Success)
+	{
+		context->Runtime().Diagnostics().Add(loadResult, "Failed to load mesh source file.");
+		return mappedResult;
+	}
+
+	try
+	{
+		Internal::Blob blob(std::move(rawBytes), Internal::MakeBlobSourceMetadata(filePath));
+		return DecodeMeshBlob(context->Runtime(), blob, outMesh);
+	}
+	catch (const std::bad_alloc&)
+	{
+		return Result::ErrorOutOfMemory;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
+	}
 }
 
 AssetSuite::Result AssetSuite::ReleaseBlob(ContextHandle context, BlobHandle* blob)

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -58,167 +58,6 @@ namespace
 		}
 	}
 
-	AssetSuite::PixelFormat MapImagePixelFormat(AssetSuite::ImageFormat format) noexcept
-	{
-		switch (format)
-		{
-		case AssetSuite::ImageFormat::RGB8:
-			return AssetSuite::PixelFormat::RGB8;
-		case AssetSuite::ImageFormat::RGBA8:
-			return AssetSuite::PixelFormat::RGBA8;
-		default:
-			return AssetSuite::PixelFormat::Unknown;
-		}
-	}
-
-	bool HasMinimumImageDecodeBytes(AssetSuite::ImageDecoders decoder, const AssetSuite::Internal::Blob& blob) noexcept
-	{
-		switch (decoder)
-		{
-		case AssetSuite::ImageDecoders::BMP:
-			return blob.ByteSize() >= 54;
-		case AssetSuite::ImageDecoders::PNG:
-			return blob.ByteSize() >= 8;
-		default:
-			return blob.ByteSize() > 0;
-		}
-	}
-
-	bool HasMinimumMeshDecodeBytes(AssetSuite::MeshDecoders decoder, const AssetSuite::Internal::Blob& blob) noexcept
-	{
-		switch (decoder)
-		{
-		case AssetSuite::MeshDecoders::WAVEFRONT:
-			return blob.ByteSize() > 0;
-		default:
-			return blob.ByteSize() > 0;
-		}
-	}
-
-	AssetSuite::Result DecodeImageBlob(
-		AssetSuite::Internal::RuntimeContext& runtime,
-		const AssetSuite::Internal::Blob& blob,
-		AssetSuite::ImageHandle* outImage)
-	{
-		const AssetSuite::ImageDecoders decoder = runtime.CodecRegistry().ProbeImageDecoder(
-			blob.SourceMetadata().extension,
-			blob.Data(),
-			static_cast<size_t>(blob.ByteSize()));
-		if (decoder == AssetSuite::ImageDecoders::Auto)
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Image blob format is not supported.");
-			return AssetSuite::Result::ErrorUnsupportedFormat;
-		}
-
-		if (!HasMinimumImageDecodeBytes(decoder, blob))
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Image blob is too small for the selected decoder.");
-			return AssetSuite::Result::ErrorMalformedData;
-		}
-
-		AssetSuite::ImageDecoder* imageDecoder = runtime.CodecRegistry().FindImageDecoder(decoder);
-		if (!imageDecoder)
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Image decoder is not registered.");
-			return AssetSuite::Result::ErrorUnsupportedFormat;
-		}
-
-		std::vector<BYTE> decodedBytes;
-		AssetSuite::ImageDescriptor descriptor = {};
-		if (!imageDecoder->Decode(decodedBytes, const_cast<BYTE*>(reinterpret_cast<const BYTE*>(blob.Data())), descriptor))
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Image decoder rejected malformed data.");
-			return AssetSuite::Result::ErrorMalformedData;
-		}
-
-		AssetSuite::ImageDesc publicDesc = {
-			sizeof(AssetSuite::ImageDesc),
-			descriptor.width,
-			descriptor.height,
-			MapImagePixelFormat(descriptor.format),
-			1,
-			1
-		};
-
-		try
-		{
-			*outImage = runtime.ImageStorage().Create(publicDesc, std::move(decodedBytes));
-		}
-		catch (const std::bad_alloc&)
-		{
-			return AssetSuite::Result::ErrorOutOfMemory;
-		}
-		catch (...)
-		{
-			return AssetSuite::Result::ErrorUnknown;
-		}
-
-		return AssetSuite::Result::Success;
-	}
-
-	AssetSuite::Result DecodeMeshBlob(
-		AssetSuite::Internal::RuntimeContext& runtime,
-		const AssetSuite::Internal::Blob& blob,
-		AssetSuite::MeshHandle* outMesh)
-	{
-		const AssetSuite::MeshDecoders decoder = runtime.CodecRegistry().ProbeMeshDecoder(
-			blob.SourceMetadata().extension,
-			blob.Data(),
-			static_cast<size_t>(blob.ByteSize()));
-		if (decoder == AssetSuite::MeshDecoders::Auto)
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Mesh blob format is not supported.");
-			return AssetSuite::Result::ErrorUnsupportedFormat;
-		}
-
-		if (!HasMinimumMeshDecodeBytes(decoder, blob))
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Mesh blob is too small for the selected decoder.");
-			return AssetSuite::Result::ErrorMalformedData;
-		}
-
-		AssetSuite::MeshDecoder* meshDecoder = runtime.CodecRegistry().FindMeshDecoder(decoder);
-		if (!meshDecoder)
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Mesh decoder is not registered.");
-			return AssetSuite::Result::ErrorUnsupportedFormat;
-		}
-
-		std::vector<BYTE> decodeBuffer(blob.Data(), blob.Data() + static_cast<size_t>(blob.ByteSize()));
-		decodeBuffer.push_back('\0');
-
-		std::vector<BYTE> decodedBytes;
-		AssetSuite::MeshDescriptor descriptor = {};
-		if (!meshDecoder->Decode(decodedBytes, decodeBuffer.data(), descriptor))
-		{
-			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Mesh decoder rejected malformed data.");
-			return AssetSuite::Result::ErrorMalformedData;
-		}
-
-		AssetSuite::MeshDesc publicDesc = {
-			sizeof(AssetSuite::MeshDesc),
-			descriptor.numOfVertices,
-			descriptor.numOfIndices,
-			0,
-			0
-		};
-
-		try
-		{
-			*outMesh = runtime.MeshStorage().Create(publicDesc, std::move(decodedBytes));
-		}
-		catch (const std::bad_alloc&)
-		{
-			return AssetSuite::Result::ErrorOutOfMemory;
-		}
-		catch (...)
-		{
-			return AssetSuite::Result::ErrorUnknown;
-		}
-
-		return AssetSuite::Result::Success;
-	}
-
 	AssetSuite::ErrorCode LoadRuntimeFileToMemory(
 		AssetSuite::Internal::RuntimeContext& runtime,
 		const std::filesystem::path& filePath,
@@ -387,7 +226,7 @@ AssetSuite::Result AssetSuite::DecodeImage(ContextHandle context, BlobHandle blo
 		return Result::ErrorInvalidHandle;
 	}
 
-	return DecodeImageBlob(context->Runtime(), *storedBlob, outImage);
+	return context->Runtime().DecodeImageBlob(*storedBlob, outImage);
 }
 
 AssetSuite::Result AssetSuite::DecodeImageFromFile(ContextHandle context, const char* filePath, ImageHandle* outImage)
@@ -414,7 +253,7 @@ AssetSuite::Result AssetSuite::DecodeImageFromFile(ContextHandle context, const 
 	try
 	{
 		Internal::Blob blob(std::move(rawBytes), Internal::MakeBlobSourceMetadata(filePath));
-		return DecodeImageBlob(context->Runtime(), blob, outImage);
+		return context->Runtime().DecodeImageBlob(blob, outImage);
 	}
 	catch (const std::bad_alloc&)
 	{
@@ -449,7 +288,7 @@ AssetSuite::Result AssetSuite::DecodeMesh(ContextHandle context, BlobHandle blob
 		return Result::ErrorInvalidHandle;
 	}
 
-	return DecodeMeshBlob(context->Runtime(), *storedBlob, outMesh);
+	return context->Runtime().DecodeMeshBlob(*storedBlob, outMesh);
 }
 
 AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const char* filePath, MeshHandle* outMesh)
@@ -476,7 +315,7 @@ AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const c
 	try
 	{
 		Internal::Blob blob(std::move(rawBytes), Internal::MakeBlobSourceMetadata(filePath));
-		return DecodeMeshBlob(context->Runtime(), blob, outMesh);
+		return context->Runtime().DecodeMeshBlob(blob, outMesh);
 	}
 	catch (const std::bad_alloc&)
 	{

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -58,6 +58,167 @@ namespace
 		}
 	}
 
+	AssetSuite::PixelFormat MapImagePixelFormat(AssetSuite::ImageFormat format) noexcept
+	{
+		switch (format)
+		{
+		case AssetSuite::ImageFormat::RGB8:
+			return AssetSuite::PixelFormat::RGB8;
+		case AssetSuite::ImageFormat::RGBA8:
+			return AssetSuite::PixelFormat::RGBA8;
+		default:
+			return AssetSuite::PixelFormat::Unknown;
+		}
+	}
+
+	bool HasMinimumImageDecodeBytes(AssetSuite::ImageDecoders decoder, const AssetSuite::Internal::Blob& blob) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::ImageDecoders::BMP:
+			return blob.ByteSize() >= 54;
+		case AssetSuite::ImageDecoders::PNG:
+			return blob.ByteSize() >= 8;
+		default:
+			return blob.ByteSize() > 0;
+		}
+	}
+
+	bool HasMinimumMeshDecodeBytes(AssetSuite::MeshDecoders decoder, const AssetSuite::Internal::Blob& blob) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::MeshDecoders::WAVEFRONT:
+			return blob.ByteSize() > 0;
+		default:
+			return blob.ByteSize() > 0;
+		}
+	}
+
+	AssetSuite::Result DecodeImageBlob(
+		AssetSuite::Internal::RuntimeContext& runtime,
+		const AssetSuite::Internal::Blob& blob,
+		AssetSuite::ImageHandle* outImage)
+	{
+		const AssetSuite::ImageDecoders decoder = runtime.CodecRegistry().ProbeImageDecoder(
+			blob.SourceMetadata().extension,
+			blob.Data(),
+			static_cast<size_t>(blob.ByteSize()));
+		if (decoder == AssetSuite::ImageDecoders::Auto)
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Image blob format is not supported.");
+			return AssetSuite::Result::ErrorUnsupportedFormat;
+		}
+
+		if (!HasMinimumImageDecodeBytes(decoder, blob))
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Image blob is too small for the selected decoder.");
+			return AssetSuite::Result::ErrorMalformedData;
+		}
+
+		AssetSuite::ImageDecoder* imageDecoder = runtime.CodecRegistry().FindImageDecoder(decoder);
+		if (!imageDecoder)
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Image decoder is not registered.");
+			return AssetSuite::Result::ErrorUnsupportedFormat;
+		}
+
+		std::vector<BYTE> decodedBytes;
+		AssetSuite::ImageDescriptor descriptor = {};
+		if (!imageDecoder->Decode(decodedBytes, const_cast<BYTE*>(reinterpret_cast<const BYTE*>(blob.Data())), descriptor))
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Image decoder rejected malformed data.");
+			return AssetSuite::Result::ErrorMalformedData;
+		}
+
+		AssetSuite::ImageDesc publicDesc = {
+			sizeof(AssetSuite::ImageDesc),
+			descriptor.width,
+			descriptor.height,
+			MapImagePixelFormat(descriptor.format),
+			1,
+			1
+		};
+
+		try
+		{
+			*outImage = runtime.ImageStorage().Create(publicDesc, std::move(decodedBytes));
+		}
+		catch (const std::bad_alloc&)
+		{
+			return AssetSuite::Result::ErrorOutOfMemory;
+		}
+		catch (...)
+		{
+			return AssetSuite::Result::ErrorUnknown;
+		}
+
+		return AssetSuite::Result::Success;
+	}
+
+	AssetSuite::Result DecodeMeshBlob(
+		AssetSuite::Internal::RuntimeContext& runtime,
+		const AssetSuite::Internal::Blob& blob,
+		AssetSuite::MeshHandle* outMesh)
+	{
+		const AssetSuite::MeshDecoders decoder = runtime.CodecRegistry().ProbeMeshDecoder(
+			blob.SourceMetadata().extension,
+			blob.Data(),
+			static_cast<size_t>(blob.ByteSize()));
+		if (decoder == AssetSuite::MeshDecoders::Auto)
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Mesh blob format is not supported.");
+			return AssetSuite::Result::ErrorUnsupportedFormat;
+		}
+
+		if (!HasMinimumMeshDecodeBytes(decoder, blob))
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Mesh blob is too small for the selected decoder.");
+			return AssetSuite::Result::ErrorMalformedData;
+		}
+
+		AssetSuite::MeshDecoder* meshDecoder = runtime.CodecRegistry().FindMeshDecoder(decoder);
+		if (!meshDecoder)
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::FileTypeNotSupported, "Mesh decoder is not registered.");
+			return AssetSuite::Result::ErrorUnsupportedFormat;
+		}
+
+		std::vector<BYTE> decodeBuffer(blob.Data(), blob.Data() + static_cast<size_t>(blob.ByteSize()));
+		decodeBuffer.push_back('\0');
+
+		std::vector<BYTE> decodedBytes;
+		AssetSuite::MeshDescriptor descriptor = {};
+		if (!meshDecoder->Decode(decodedBytes, decodeBuffer.data(), descriptor))
+		{
+			runtime.Diagnostics().Add(AssetSuite::ErrorCode::Undefined, "Mesh decoder rejected malformed data.");
+			return AssetSuite::Result::ErrorMalformedData;
+		}
+
+		AssetSuite::MeshDesc publicDesc = {
+			sizeof(AssetSuite::MeshDesc),
+			descriptor.numOfVertices,
+			descriptor.numOfIndices,
+			0,
+			0
+		};
+
+		try
+		{
+			*outMesh = runtime.MeshStorage().Create(publicDesc, std::move(decodedBytes));
+		}
+		catch (const std::bad_alloc&)
+		{
+			return AssetSuite::Result::ErrorOutOfMemory;
+		}
+		catch (...)
+		{
+			return AssetSuite::Result::ErrorUnknown;
+		}
+
+		return AssetSuite::Result::Success;
+	}
+
 	AssetSuite::ErrorCode LoadRuntimeFileToMemory(
 		AssetSuite::Internal::RuntimeContext& runtime,
 		const std::filesystem::path& filePath,
@@ -220,7 +381,13 @@ AssetSuite::Result AssetSuite::DecodeImage(ContextHandle context, BlobHandle blo
 		return Result::ErrorInvalidArgument;
 	}
 
-	return Result::ErrorUnsupportedFormat;
+	const Internal::Blob* storedBlob = context->Runtime().BlobStorage().Get(blob);
+	if (!storedBlob)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	return DecodeImageBlob(context->Runtime(), *storedBlob, outImage);
 }
 
 AssetSuite::Result AssetSuite::DecodeImageFromFile(ContextHandle context, const char* filePath, ImageHandle* outImage)
@@ -255,7 +422,13 @@ AssetSuite::Result AssetSuite::DecodeMesh(ContextHandle context, BlobHandle blob
 		return Result::ErrorInvalidArgument;
 	}
 
-	return Result::ErrorUnsupportedFormat;
+	const Internal::Blob* storedBlob = context->Runtime().BlobStorage().Get(blob);
+	if (!storedBlob)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	return DecodeMeshBlob(context->Runtime(), *storedBlob, outMesh);
 }
 
 AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const char* filePath, MeshHandle* outMesh)

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -114,6 +114,8 @@ const char* AssetSuite::GetResultString(Result result)
 		return "Error: invalid handle";
 	case Result::ErrorIoFailure:
 		return "Error: IO failure";
+	case Result::ErrorMalformedData:
+		return "Error: malformed data";
 	case Result::ErrorUnknown:
 		return "Error: unknown";
 	default:
@@ -199,6 +201,76 @@ AssetSuite::Result AssetSuite::LoadFile(ContextHandle context, const char* fileP
 	}
 
 	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::DecodeImage(ContextHandle context, BlobHandle blob, ImageHandle* outImage)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!blob)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	if (!outImage || *outImage)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	return Result::ErrorUnsupportedFormat;
+}
+
+AssetSuite::Result AssetSuite::DecodeImageFromFile(ContextHandle context, const char* filePath, ImageHandle* outImage)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!filePath || !outImage || *outImage)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	return Result::ErrorUnsupportedFormat;
+}
+
+AssetSuite::Result AssetSuite::DecodeMesh(ContextHandle context, BlobHandle blob, MeshHandle* outMesh)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!blob)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	if (!outMesh || *outMesh)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	return Result::ErrorUnsupportedFormat;
+}
+
+AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const char* filePath, MeshHandle* outMesh)
+{
+	if (!context)
+	{
+		return Result::ErrorInvalidContext;
+	}
+
+	if (!filePath || !outMesh || *outMesh)
+	{
+		return Result::ErrorInvalidArgument;
+	}
+
+	return Result::ErrorUnsupportedFormat;
 }
 
 AssetSuite::Result AssetSuite::ReleaseBlob(ContextHandle context, BlobHandle* blob)

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -61,6 +61,30 @@ AssetSuite::Internal::RuntimeContext::BlobStorage() const noexcept
 	return state.blobStorage;
 }
 
+AssetSuite::Internal::RuntimeState::ImageStorage&
+AssetSuite::Internal::RuntimeContext::ImageStorage() noexcept
+{
+	return state.imageStorage;
+}
+
+const AssetSuite::Internal::RuntimeState::ImageStorage&
+AssetSuite::Internal::RuntimeContext::ImageStorage() const noexcept
+{
+	return state.imageStorage;
+}
+
+AssetSuite::Internal::RuntimeState::MeshStorage&
+AssetSuite::Internal::RuntimeContext::MeshStorage() noexcept
+{
+	return state.meshStorage;
+}
+
+const AssetSuite::Internal::RuntimeState::MeshStorage&
+AssetSuite::Internal::RuntimeContext::MeshStorage() const noexcept
+{
+	return state.meshStorage;
+}
+
 AssetSuite::Internal::RuntimeState::CodecRegistry&
 AssetSuite::Internal::RuntimeContext::CodecRegistry() noexcept
 {

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -1,5 +1,49 @@
 #include "AssetSuiteRuntime.h"
 
+#include <new>
+#include <utility>
+#include <vector>
+
+namespace
+{
+	AssetSuite::PixelFormat MapImagePixelFormat(AssetSuite::ImageFormat format) noexcept
+	{
+		switch (format)
+		{
+		case AssetSuite::ImageFormat::RGB8:
+			return AssetSuite::PixelFormat::RGB8;
+		case AssetSuite::ImageFormat::RGBA8:
+			return AssetSuite::PixelFormat::RGBA8;
+		default:
+			return AssetSuite::PixelFormat::Unknown;
+		}
+	}
+
+	bool HasMinimumImageDecodeBytes(AssetSuite::ImageDecoders decoder, const AssetSuite::Internal::Blob& blob) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::ImageDecoders::BMP:
+			return blob.ByteSize() >= 54;
+		case AssetSuite::ImageDecoders::PNG:
+			return blob.ByteSize() >= 8;
+		default:
+			return blob.ByteSize() > 0;
+		}
+	}
+
+	bool HasMinimumMeshDecodeBytes(AssetSuite::MeshDecoders decoder, const AssetSuite::Internal::Blob& blob) noexcept
+	{
+		switch (decoder)
+		{
+		case AssetSuite::MeshDecoders::WAVEFRONT:
+			return blob.ByteSize() > 0;
+		default:
+			return blob.ByteSize() > 0;
+		}
+	}
+}
+
 AssetSuite::Internal::RuntimeContext::RuntimeContext(const ContextDesc& desc)
 	: desc(desc)
 	, state()
@@ -95,6 +139,128 @@ const AssetSuite::Internal::RuntimeState::CodecRegistry&
 AssetSuite::Internal::RuntimeContext::CodecRegistry() const noexcept
 {
 	return state.codecRegistry;
+}
+
+AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeImageBlob(
+	const Blob& blob,
+	ImageHandle* outImage)
+{
+	const ImageDecoders decoder = CodecRegistry().ProbeImageDecoder(
+		blob.SourceMetadata().extension,
+		blob.Data(),
+		static_cast<size_t>(blob.ByteSize()));
+	if (decoder == ImageDecoders::Auto)
+	{
+		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Image blob format is not supported.");
+		return Result::ErrorUnsupportedFormat;
+	}
+
+	if (!HasMinimumImageDecodeBytes(decoder, blob))
+	{
+		Diagnostics().Add(ErrorCode::Undefined, "Image blob is too small for the selected decoder.");
+		return Result::ErrorMalformedData;
+	}
+
+	ImageDecoder* imageDecoder = CodecRegistry().FindImageDecoder(decoder);
+	if (!imageDecoder)
+	{
+		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Image decoder is not registered.");
+		return Result::ErrorUnsupportedFormat;
+	}
+
+	std::vector<BYTE> decodedBytes;
+	ImageDescriptor descriptor = {};
+	if (!imageDecoder->Decode(decodedBytes, const_cast<BYTE*>(reinterpret_cast<const BYTE*>(blob.Data())), descriptor))
+	{
+		Diagnostics().Add(ErrorCode::Undefined, "Image decoder rejected malformed data.");
+		return Result::ErrorMalformedData;
+	}
+
+	ImageDesc publicDesc = {
+		sizeof(ImageDesc),
+		descriptor.width,
+		descriptor.height,
+		MapImagePixelFormat(descriptor.format),
+		1,
+		1
+	};
+
+	try
+	{
+		*outImage = ImageStorage().Create(publicDesc, std::move(decodedBytes));
+	}
+	catch (const std::bad_alloc&)
+	{
+		return Result::ErrorOutOfMemory;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
+	}
+
+	return Result::Success;
+}
+
+AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeMeshBlob(
+	const Blob& blob,
+	MeshHandle* outMesh)
+{
+	const MeshDecoders decoder = CodecRegistry().ProbeMeshDecoder(
+		blob.SourceMetadata().extension,
+		blob.Data(),
+		static_cast<size_t>(blob.ByteSize()));
+	if (decoder == MeshDecoders::Auto)
+	{
+		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Mesh blob format is not supported.");
+		return Result::ErrorUnsupportedFormat;
+	}
+
+	if (!HasMinimumMeshDecodeBytes(decoder, blob))
+	{
+		Diagnostics().Add(ErrorCode::Undefined, "Mesh blob is too small for the selected decoder.");
+		return Result::ErrorMalformedData;
+	}
+
+	MeshDecoder* meshDecoder = CodecRegistry().FindMeshDecoder(decoder);
+	if (!meshDecoder)
+	{
+		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Mesh decoder is not registered.");
+		return Result::ErrorUnsupportedFormat;
+	}
+
+	std::vector<BYTE> decodeBuffer(blob.Data(), blob.Data() + static_cast<size_t>(blob.ByteSize()));
+	decodeBuffer.push_back('\0');
+
+	std::vector<BYTE> decodedBytes;
+	MeshDescriptor descriptor = {};
+	if (!meshDecoder->Decode(decodedBytes, decodeBuffer.data(), descriptor))
+	{
+		Diagnostics().Add(ErrorCode::Undefined, "Mesh decoder rejected malformed data.");
+		return Result::ErrorMalformedData;
+	}
+
+	MeshDesc publicDesc = {
+		sizeof(MeshDesc),
+		descriptor.numOfVertices,
+		descriptor.numOfIndices,
+		0,
+		0
+	};
+
+	try
+	{
+		*outMesh = MeshStorage().Create(publicDesc, std::move(decodedBytes));
+	}
+	catch (const std::bad_alloc&)
+	{
+		return Result::ErrorOutOfMemory;
+	}
+	catch (...)
+	{
+		return Result::ErrorUnknown;
+	}
+
+	return Result::Success;
 }
 
 void AssetSuite::Internal::RuntimeContext::SetLoggingCallback(

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -42,6 +42,13 @@ namespace
 			return blob.ByteSize() > 0;
 		}
 	}
+
+	AssetSuite::Result MapSelectedDecoderFailure() noexcept
+	{
+		// Current decoder interfaces return only bool, so a selected decoder
+		// rejecting bytes is the best available malformed-input signal.
+		return AssetSuite::Result::ErrorMalformedData;
+	}
 }
 
 AssetSuite::Internal::RuntimeContext::RuntimeContext(const ContextDesc& desc)
@@ -173,7 +180,7 @@ AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeImageBlob(
 	if (!imageDecoder->Decode(decodedBytes, const_cast<BYTE*>(reinterpret_cast<const BYTE*>(blob.Data())), descriptor))
 	{
 		Diagnostics().Add(ErrorCode::Undefined, "Image decoder rejected malformed data.");
-		return Result::ErrorMalformedData;
+		return MapSelectedDecoderFailure();
 	}
 
 	ImageDesc publicDesc = {
@@ -236,7 +243,7 @@ AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeMeshBlob(
 	if (!meshDecoder->Decode(decodedBytes, decodeBuffer.data(), descriptor))
 	{
 		Diagnostics().Add(ErrorCode::Undefined, "Mesh decoder rejected malformed data.");
-		return Result::ErrorMalformedData;
+		return MapSelectedDecoderFailure();
 	}
 
 	MeshDesc publicDesc = {

--- a/source/runtime/AssetSuiteRuntime.h
+++ b/source/runtime/AssetSuiteRuntime.h
@@ -31,6 +31,8 @@ namespace AssetSuite::Internal
 		const RuntimeState::MeshStorage& MeshStorage() const noexcept;
 		RuntimeState::CodecRegistry& CodecRegistry() noexcept;
 		const RuntimeState::CodecRegistry& CodecRegistry() const noexcept;
+		Result DecodeImageBlob(const Blob& blob, ImageHandle* outImage);
+		Result DecodeMeshBlob(const Blob& blob, MeshHandle* outMesh);
 
 		void SetLoggingCallback(LoggingCallback callback, LogLevel minimumLevel, void* userData) noexcept;
 		void DispatchLogEvent(LogLevel level, const char* message) const;

--- a/source/runtime/AssetSuiteRuntime.h
+++ b/source/runtime/AssetSuiteRuntime.h
@@ -25,6 +25,10 @@ namespace AssetSuite::Internal
 		RuntimeState::FileLoader& FileLoader() noexcept;
 		RuntimeState::BlobStorage& BlobStorage() noexcept;
 		const RuntimeState::BlobStorage& BlobStorage() const noexcept;
+		RuntimeState::ImageStorage& ImageStorage() noexcept;
+		const RuntimeState::ImageStorage& ImageStorage() const noexcept;
+		RuntimeState::MeshStorage& MeshStorage() noexcept;
+		const RuntimeState::MeshStorage& MeshStorage() const noexcept;
 		RuntimeState::CodecRegistry& CodecRegistry() noexcept;
 		const RuntimeState::CodecRegistry& CodecRegistry() const noexcept;
 

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -517,6 +517,90 @@ size_t AssetSuite::Internal::RuntimeState::BlobStorage::SlotCapacity() const noe
 	return slots.size();
 }
 
+AssetSuite::ImageHandle AssetSuite::Internal::RuntimeState::ImageStorage::Create(
+	ImageDesc desc,
+	std::vector<uint8_t> bytes)
+{
+	auto image = std::make_unique<AssetSuiteImage_t>();
+	image->desc = desc;
+	image->bytes = std::move(bytes);
+
+	ImageHandle handle = image.get();
+	images.push_back(std::move(image));
+	return handle;
+}
+
+bool AssetSuite::Internal::RuntimeState::ImageStorage::Owns(ImageHandle image) const noexcept
+{
+	return Get(image) != nullptr;
+}
+
+const AssetSuite::AssetSuiteImage_t*
+AssetSuite::Internal::RuntimeState::ImageStorage::Get(ImageHandle image) const noexcept
+{
+	if (!image)
+	{
+		return nullptr;
+	}
+
+	for (const auto& storedImage : images)
+	{
+		if (storedImage.get() == image)
+		{
+			return storedImage.get();
+		}
+	}
+
+	return nullptr;
+}
+
+size_t AssetSuite::Internal::RuntimeState::ImageStorage::LiveCount() const noexcept
+{
+	return images.size();
+}
+
+AssetSuite::MeshHandle AssetSuite::Internal::RuntimeState::MeshStorage::Create(
+	MeshDesc desc,
+	std::vector<uint8_t> bytes)
+{
+	auto mesh = std::make_unique<AssetSuiteMesh_t>();
+	mesh->desc = desc;
+	mesh->bytes = std::move(bytes);
+
+	MeshHandle handle = mesh.get();
+	meshes.push_back(std::move(mesh));
+	return handle;
+}
+
+bool AssetSuite::Internal::RuntimeState::MeshStorage::Owns(MeshHandle mesh) const noexcept
+{
+	return Get(mesh) != nullptr;
+}
+
+const AssetSuite::AssetSuiteMesh_t*
+AssetSuite::Internal::RuntimeState::MeshStorage::Get(MeshHandle mesh) const noexcept
+{
+	if (!mesh)
+	{
+		return nullptr;
+	}
+
+	for (const auto& storedMesh : meshes)
+	{
+		if (storedMesh.get() == mesh)
+		{
+			return storedMesh.get();
+		}
+	}
+
+	return nullptr;
+}
+
+size_t AssetSuite::Internal::RuntimeState::MeshStorage::LiveCount() const noexcept
+{
+	return meshes.size();
+}
+
 bool AssetSuite::Internal::RuntimeState::CodecRegistry::RegisterImageDecoder(
 	ImageDecoders decoder,
 	ImageDecoder& implementation)

--- a/source/runtime/AssetSuiteRuntimeState.cpp
+++ b/source/runtime/AssetSuiteRuntimeState.cpp
@@ -554,6 +554,26 @@ AssetSuite::Internal::RuntimeState::ImageStorage::Get(ImageHandle image) const n
 	return nullptr;
 }
 
+AssetSuite::Result AssetSuite::Internal::RuntimeState::ImageStorage::Release(ImageHandle* image) noexcept
+{
+	if (!image || !*image)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	for (auto storedImage = images.begin(); storedImage != images.end(); ++storedImage)
+	{
+		if (storedImage->get() == *image)
+		{
+			images.erase(storedImage);
+			*image = nullptr;
+			return Result::Success;
+		}
+	}
+
+	return Result::ErrorInvalidHandle;
+}
+
 size_t AssetSuite::Internal::RuntimeState::ImageStorage::LiveCount() const noexcept
 {
 	return images.size();
@@ -594,6 +614,26 @@ AssetSuite::Internal::RuntimeState::MeshStorage::Get(MeshHandle mesh) const noex
 	}
 
 	return nullptr;
+}
+
+AssetSuite::Result AssetSuite::Internal::RuntimeState::MeshStorage::Release(MeshHandle* mesh) noexcept
+{
+	if (!mesh || !*mesh)
+	{
+		return Result::ErrorInvalidHandle;
+	}
+
+	for (auto storedMesh = meshes.begin(); storedMesh != meshes.end(); ++storedMesh)
+	{
+		if (storedMesh->get() == *mesh)
+		{
+			meshes.erase(storedMesh);
+			*mesh = nullptr;
+			return Result::Success;
+		}
+	}
+
+	return Result::ErrorInvalidHandle;
 }
 
 size_t AssetSuite::Internal::RuntimeState::MeshStorage::LiveCount() const noexcept

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -105,6 +105,7 @@ namespace AssetSuite::Internal
 			ImageHandle Create(ImageDesc desc, std::vector<uint8_t> bytes);
 			bool Owns(ImageHandle image) const noexcept;
 			const AssetSuiteImage_t* Get(ImageHandle image) const noexcept;
+			Result Release(ImageHandle* image) noexcept;
 			size_t LiveCount() const noexcept;
 
 		private:
@@ -116,6 +117,7 @@ namespace AssetSuite::Internal
 			MeshHandle Create(MeshDesc desc, std::vector<uint8_t> bytes);
 			bool Owns(MeshHandle mesh) const noexcept;
 			const AssetSuiteMesh_t* Get(MeshHandle mesh) const noexcept;
+			Result Release(MeshHandle* mesh) noexcept;
 			size_t LiveCount() const noexcept;
 
 		private:

--- a/source/runtime/AssetSuiteRuntimeState.h
+++ b/source/runtime/AssetSuiteRuntimeState.h
@@ -24,6 +24,18 @@ namespace AssetSuite
 	class PngDecoder;
 	class PpmEncoder;
 	class BypassEncoder;
+
+	struct AssetSuiteImage_t
+	{
+		ImageDesc desc = {};
+		std::vector<uint8_t> bytes;
+	};
+
+	struct AssetSuiteMesh_t
+	{
+		MeshDesc desc = {};
+		std::vector<uint8_t> bytes;
+	};
 }
 
 namespace AssetSuite::Internal
@@ -86,6 +98,28 @@ namespace AssetSuite::Internal
 			uint32_t contextId = 0;
 			std::vector<Slot> slots;
 			std::vector<size_t> freeSlots;
+		};
+
+		struct ImageStorage
+		{
+			ImageHandle Create(ImageDesc desc, std::vector<uint8_t> bytes);
+			bool Owns(ImageHandle image) const noexcept;
+			const AssetSuiteImage_t* Get(ImageHandle image) const noexcept;
+			size_t LiveCount() const noexcept;
+
+		private:
+			std::vector<std::unique_ptr<AssetSuiteImage_t>> images;
+		};
+
+		struct MeshStorage
+		{
+			MeshHandle Create(MeshDesc desc, std::vector<uint8_t> bytes);
+			bool Owns(MeshHandle mesh) const noexcept;
+			const AssetSuiteMesh_t* Get(MeshHandle mesh) const noexcept;
+			size_t LiveCount() const noexcept;
+
+		private:
+			std::vector<std::unique_ptr<AssetSuiteMesh_t>> meshes;
 		};
 
 		struct CodecRegistry
@@ -193,6 +227,8 @@ namespace AssetSuite::Internal
 		Diagnostics diagnostics;
 		FileLoader fileLoader;
 		BlobStorage blobStorage;
+		ImageStorage imageStorage;
+		MeshStorage meshStorage;
 		CodecRegistry codecRegistry;
 	};
 }

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -12,6 +12,7 @@ The runtime currently owns:
 - diagnostics storage
 - file loading support
 - private blob handle storage, raw bytes, and copied source metadata
+- private decoded image and mesh handle storage
 - source file metadata
 - raw, decoded, and formatted buffers
 - transient image and mesh metadata
@@ -42,6 +43,24 @@ The public SDK surface is guarded by `PublicHeaderCompile`, `PublicHeaderHygiene
 
 `RuntimeState::BlobStorage` owns reusable blob slots for one context. `ReleaseBlob` clears the blob payload, advances the slot generation, returns the slot to the free list, and nulls the caller's handle. Copied stale handles are rejected by generation mismatch, and handles from another context are rejected by context-id mismatch before slot lookup.
 
+## Decode Routing
+
+Public blob and file decode entry points route through `RuntimeContext` before
+codec probing or decoder lookup occurs. Public API functions validate context,
+output, and stored blob handles, then delegate to the private runtime decode
+helpers.
+
+The runtime probes source bytes first and falls back to source extension only
+when byte signatures or content markers are inconclusive. Unsupported inputs
+return `Result::ErrorUnsupportedFormat`. Recognized inputs that are too small or
+rejected by the selected legacy `bool` decoder return
+`Result::ErrorMalformedData`.
+
+Decoded image and mesh handles are runtime-owned child objects. File decode
+entry points load bytes through the shared file loader and wrap them in a
+temporary internal blob object, so successful file decode does not create a
+persistent public `BlobHandle`.
+
 ## File Loading
 
 `RuntimeState::FileLoader` is the shared file-read service for public blob loading and the legacy `Manager` image/mesh file entry points. Missing paths return `ErrorCode::NonExistingFile`, while existing paths that cannot be opened, sized, or fully read return `ErrorCode::IoFailure`.
@@ -52,8 +71,6 @@ The public SDK adapter maps `NonExistingFile` to `Result::ErrorFileNotFound` and
 
 This runtime layer is intentionally foundational. The following work is deferred to later stories:
 
-- image and mesh child-handle tracking
-- codec probing and richer format detection
 - public diagnostics reporting
 - allocator hooks wired into all internal allocations
 - broader asset storage and cleanup policies

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -199,6 +199,7 @@ namespace GeneralUnitTests
 			AssertResultString(AssetSuite::Result::ErrorInvalidContext, "Error: invalid context");
 			AssertResultString(AssetSuite::Result::ErrorInvalidHandle, "Error: invalid handle");
 			AssertResultString(AssetSuite::Result::ErrorIoFailure, "Error: IO failure");
+			AssertResultString(AssetSuite::Result::ErrorMalformedData, "Error: malformed data");
 			AssertResultString(AssetSuite::Result::ErrorUnknown, "Error: unknown");
 		}
 

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -699,6 +699,55 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(firstContext);
 		}
 
+		TEST_METHOD(DecodeImageFromFileUsesSharedRoutingWithoutPersistingBlob)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			const auto result = AssetSuite::DecodeImageFromFile(context, "test_file.xyz", &image);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNotNull(image);
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().ImageStorage().LiveCount());
+			Assert::IsTrue(context->Runtime().ImageStorage().Owns(image));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(DecodeMeshFromFileUsesSharedRoutingWithoutPersistingBlob)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::MeshHandle mesh = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			const auto result = AssetSuite::DecodeMeshFromFile(context, "test_mesh.obj", &mesh);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNotNull(mesh);
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().MeshStorage().LiveCount());
+			Assert::IsTrue(context->Runtime().MeshStorage().Owns(mesh));
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(DecodeFromFileMapsLoadFailures)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			AssetSuite::MeshHandle mesh = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorFileNotFound == AssetSuite::DecodeImageFromFile(context, "missing_decode_image.bmp", &image));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorIoFailure == AssetSuite::DecodeMeshFromFile(context, std::filesystem::current_path().string().c_str(), &mesh));
+			Assert::IsNull(image);
+			Assert::IsNull(mesh);
+
+			DestroyContextForCleanup(context);
+		}
+
 		TEST_METHOD(BlobStorageReusesReleasedSlotsAndRejectsOldGenerations)
 		{
 			AssetSuite::ContextHandle context = nullptr;

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -710,6 +710,7 @@ namespace GeneralUnitTests
 		{
 			AssetSuite::ContextHandle context = nullptr;
 			AssetSuite::ImageHandle image = nullptr;
+			AssetSuite::ImageDesc imageDesc = {};
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
 
 			const auto result = AssetSuite::DecodeImageFromFile(context, "test_file.xyz", &image);
@@ -719,6 +720,11 @@ namespace GeneralUnitTests
 			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
 			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().ImageStorage().LiveCount());
 			Assert::IsTrue(context->Runtime().ImageStorage().Owns(image));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::GetImageDesc(context, image, &imageDesc));
+			Assert::AreEqual(true, AssetSuite::PixelFormat::RGB8 == imageDesc.format);
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseImage(context, &image));
+			Assert::IsNull(image);
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().ImageStorage().LiveCount());
 
 			DestroyContextForCleanup(context);
 		}
@@ -727,6 +733,7 @@ namespace GeneralUnitTests
 		{
 			AssetSuite::ContextHandle context = nullptr;
 			AssetSuite::MeshHandle mesh = nullptr;
+			AssetSuite::MeshDesc meshDesc = {};
 			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
 
 			const auto result = AssetSuite::DecodeMeshFromFile(context, "test_mesh.obj", &mesh);
@@ -736,8 +743,42 @@ namespace GeneralUnitTests
 			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().BlobStorage().LiveCount());
 			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().MeshStorage().LiveCount());
 			Assert::IsTrue(context->Runtime().MeshStorage().Owns(mesh));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::GetMeshDesc(context, mesh, &meshDesc));
+			Assert::AreEqual(static_cast<uint32_t>(sizeof(AssetSuite::MeshDesc)), meshDesc.structSize);
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseMesh(context, &mesh));
+			Assert::IsNull(mesh);
+			Assert::AreEqual(static_cast<size_t>(0), context->Runtime().MeshStorage().LiveCount());
 
 			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(DecodedHandleApisValidateContextOutputsAndOwnership)
+		{
+			AssetSuite::ContextHandle firstContext = nullptr;
+			AssetSuite::ContextHandle secondContext = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			AssetSuite::MeshHandle mesh = nullptr;
+			AssetSuite::ImageDesc imageDesc = {};
+			AssetSuite::MeshDesc meshDesc = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &firstContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &secondContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::DecodeImageFromFile(firstContext, "test_file.xyz", &image));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::DecodeMeshFromFile(firstContext, "test_mesh.obj", &mesh));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == AssetSuite::GetImageDesc(nullptr, image, &imageDesc));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == AssetSuite::GetImageDesc(firstContext, image, nullptr));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::GetImageDesc(secondContext, image, &imageDesc));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == AssetSuite::ReleaseMesh(nullptr, &mesh));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::ReleaseImage(secondContext, &image));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::GetMeshDesc(firstContext, mesh, &meshDesc));
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseMesh(firstContext, &mesh));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseImage(firstContext, &image));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::ReleaseMesh(firstContext, &mesh));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::GetImageDesc(firstContext, image, &imageDesc));
+
+			DestroyContextForCleanup(secondContext);
+			DestroyContextForCleanup(firstContext);
 		}
 
 		TEST_METHOD(DecodeFromFileMapsLoadFailures)

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -704,6 +704,37 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(context);
 		}
 
+		TEST_METHOD(RuntimeStoresDecodedImageAndMeshHandlesPerContext)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+
+			AssetSuite::ImageDesc imageDesc = { sizeof(AssetSuite::ImageDesc), 2, 3, AssetSuite::PixelFormat::RGBA8, 1, 1 };
+			AssetSuite::MeshDesc meshDesc = {
+				sizeof(AssetSuite::MeshDesc),
+				4,
+				6,
+				1,
+				static_cast<uint32_t>(AssetSuite::MeshAttributeFlags::Position)
+			};
+			std::vector<uint8_t> imageBytes = { 1, 2, 3, 4 };
+			std::vector<uint8_t> meshBytes = { 5, 6, 7, 8 };
+
+			AssetSuite::ImageHandle image = context->Runtime().ImageStorage().Create(imageDesc, std::move(imageBytes));
+			AssetSuite::MeshHandle mesh = context->Runtime().MeshStorage().Create(meshDesc, std::move(meshBytes));
+
+			Assert::IsNotNull(image);
+			Assert::IsNotNull(mesh);
+			Assert::IsTrue(context->Runtime().ImageStorage().Owns(image));
+			Assert::IsTrue(context->Runtime().MeshStorage().Owns(mesh));
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().ImageStorage().LiveCount());
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().MeshStorage().LiveCount());
+			Assert::AreEqual(static_cast<uint32_t>(2), context->Runtime().ImageStorage().Get(image)->desc.width);
+			Assert::AreEqual(static_cast<uint32_t>(4), context->Runtime().MeshStorage().Get(mesh)->desc.vertexCount);
+
+			DestroyContextForCleanup(context);
+		}
+
 		TEST_METHOD(RuntimeCodecRegistryResolvesBuiltInDecodersByExtension)
 		{
 			AssetSuite::ContextHandle context = nullptr;

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -2,6 +2,7 @@
 #include <CppUnitTest.h>
 
 #include <cstdint>
+#include <fstream>
 #include <filesystem>
 #include <utility>
 #include <vector>
@@ -82,6 +83,12 @@ namespace
 		}
 
 		return currentDirectory;
+	}
+
+	void WriteBinaryFile(const std::filesystem::path& path, const std::vector<uint8_t>& bytes)
+	{
+		std::ofstream file(path, std::ios::binary | std::ios::trunc);
+		file.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
 	}
 
 	class TestImageDecoder final : public AssetSuite::ImageDecoder
@@ -746,6 +753,50 @@ namespace GeneralUnitTests
 			Assert::IsNull(mesh);
 
 			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(DecodeImageMapsMalformedRecognizedDataConsistently)
+		{
+			const std::filesystem::path malformedImagePath = "malformed_decode_image.bmp";
+			WriteBinaryFile(malformedImagePath, { 'B', 'M' });
+
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			AssetSuite::ImageHandle blobImage = nullptr;
+			AssetSuite::ImageHandle fileImage = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, malformedImagePath.string().c_str(), &blob));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorMalformedData == AssetSuite::DecodeImage(context, blob, &blobImage));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorMalformedData == AssetSuite::DecodeImageFromFile(context, malformedImagePath.string().c_str(), &fileImage));
+			Assert::IsNull(blobImage);
+			Assert::IsNull(fileImage);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			DestroyContextForCleanup(context);
+			std::filesystem::remove(malformedImagePath);
+		}
+
+		TEST_METHOD(DecodeMeshMapsMalformedRecognizedDataConsistently)
+		{
+			const std::filesystem::path malformedMeshPath = "malformed_decode_mesh.obj";
+			WriteBinaryFile(malformedMeshPath, {});
+
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			AssetSuite::MeshHandle blobMesh = nullptr;
+			AssetSuite::MeshHandle fileMesh = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, malformedMeshPath.string().c_str(), &blob));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorMalformedData == AssetSuite::DecodeMesh(context, blob, &blobMesh));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorMalformedData == AssetSuite::DecodeMeshFromFile(context, malformedMeshPath.string().c_str(), &fileMesh));
+			Assert::IsNull(blobMesh);
+			Assert::IsNull(fileMesh);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			DestroyContextForCleanup(context);
+			std::filesystem::remove(malformedMeshPath);
 		}
 
 		TEST_METHOD(BlobStorageReusesReleasedSlotsAndRejectsOldGenerations)

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -635,6 +635,70 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(firstContext);
 		}
 
+		TEST_METHOD(DecodeImageUsesRuntimeBlobAndStoresImageHandle)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, "test_file.xyz", &blob));
+
+			const auto result = AssetSuite::DecodeImage(context, blob, &image);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNotNull(image);
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().ImageStorage().LiveCount());
+			Assert::IsTrue(context->Runtime().ImageStorage().Owns(image));
+			Assert::AreEqual(true, AssetSuite::PixelFormat::RGB8 == context->Runtime().ImageStorage().Get(image)->desc.format);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(DecodeMeshUsesRuntimeBlobAndStoresMeshHandle)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			AssetSuite::MeshHandle mesh = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, "test_mesh.obj", &blob));
+
+			const auto result = AssetSuite::DecodeMesh(context, blob, &mesh);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == result);
+			Assert::IsNotNull(mesh);
+			Assert::AreEqual(static_cast<size_t>(1), context->Runtime().MeshStorage().LiveCount());
+			Assert::IsTrue(context->Runtime().MeshStorage().Owns(mesh));
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(DecodeBlobRejectsInvalidHandlesAndUnsupportedFormats)
+		{
+			AssetSuite::ContextHandle firstContext = nullptr;
+			AssetSuite::ContextHandle secondContext = nullptr;
+			AssetSuite::BlobHandle firstBlob = nullptr;
+			AssetSuite::BlobHandle meshBlob = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &firstContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &secondContext));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(firstContext, "test_file.xyz", &firstBlob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(firstContext, "test_mesh.obj", &meshBlob));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidContext == AssetSuite::DecodeImage(nullptr, firstBlob, &image));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::DecodeImage(firstContext, nullptr, &image));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidArgument == AssetSuite::DecodeImage(firstContext, firstBlob, nullptr));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorInvalidHandle == AssetSuite::DecodeImage(secondContext, firstBlob, &image));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorUnsupportedFormat == AssetSuite::DecodeImage(firstContext, meshBlob, &image));
+			Assert::IsNull(image);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(firstContext, &meshBlob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(firstContext, &firstBlob));
+			DestroyContextForCleanup(secondContext);
+			DestroyContextForCleanup(firstContext);
+		}
+
 		TEST_METHOD(BlobStorageReusesReleasedSlotsAndRejectsOldGenerations)
 		{
 			AssetSuite::ContextHandle context = nullptr;

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -119,6 +119,18 @@ static_assert(std::is_same_v<
 	decltype(&AssetSuite::LoadFile),
 	AssetSuite::Result (*)(AssetSuite::ContextHandle, const char*, AssetSuite::BlobHandle*)>);
 static_assert(std::is_same_v<
+	decltype(&AssetSuite::DecodeImage),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::BlobHandle, AssetSuite::ImageHandle*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::DecodeImageFromFile),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, const char*, AssetSuite::ImageHandle*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::DecodeMesh),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::BlobHandle, AssetSuite::MeshHandle*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::DecodeMeshFromFile),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, const char*, AssetSuite::MeshHandle*)>);
+static_assert(std::is_same_v<
 	decltype(&AssetSuite::ReleaseBlob),
 	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::BlobHandle*)>);
 
@@ -152,6 +164,8 @@ int main()
 		AssetSuite::LogLevel::Trace,
 		nullptr);
 	const AssetSuite::Result loadNullPathResult = AssetSuite::LoadFile(context, nullptr, &blob);
+	const AssetSuite::Result decodeNullImagePathResult = AssetSuite::DecodeImageFromFile(context, nullptr, &image);
+	const AssetSuite::Result decodeNullMeshPathResult = AssetSuite::DecodeMeshFromFile(context, nullptr, &mesh);
 	const AssetSuite::Result releaseNullBlobResult = AssetSuite::ReleaseBlob(context, &blob);
 	const AssetSuite::Result destroyExplicitResult = AssetSuite::DestroyContext(&context);
 
@@ -166,6 +180,8 @@ int main()
 		setLoggingResult == AssetSuite::Result::ErrorUnknown ||
 		unregisterLoggingResult == AssetSuite::Result::ErrorUnknown ||
 		loadNullPathResult == AssetSuite::Result::ErrorUnknown ||
+		decodeNullImagePathResult == AssetSuite::Result::ErrorUnknown ||
+		decodeNullMeshPathResult == AssetSuite::Result::ErrorUnknown ||
 		releaseNullBlobResult == AssetSuite::Result::ErrorUnknown ||
 		destroyExplicitResult == AssetSuite::Result::ErrorUnknown;
 }

--- a/validation/public_header_compile/PublicHeaderCompile.cpp
+++ b/validation/public_header_compile/PublicHeaderCompile.cpp
@@ -131,6 +131,18 @@ static_assert(std::is_same_v<
 	decltype(&AssetSuite::DecodeMeshFromFile),
 	AssetSuite::Result (*)(AssetSuite::ContextHandle, const char*, AssetSuite::MeshHandle*)>);
 static_assert(std::is_same_v<
+	decltype(&AssetSuite::GetImageDesc),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::ImageHandle, AssetSuite::ImageDesc*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::GetMeshDesc),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::MeshHandle, AssetSuite::MeshDesc*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::ReleaseImage),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::ImageHandle*)>);
+static_assert(std::is_same_v<
+	decltype(&AssetSuite::ReleaseMesh),
+	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::MeshHandle*)>);
+static_assert(std::is_same_v<
 	decltype(&AssetSuite::ReleaseBlob),
 	AssetSuite::Result (*)(AssetSuite::ContextHandle, AssetSuite::BlobHandle*)>);
 
@@ -166,6 +178,10 @@ int main()
 	const AssetSuite::Result loadNullPathResult = AssetSuite::LoadFile(context, nullptr, &blob);
 	const AssetSuite::Result decodeNullImagePathResult = AssetSuite::DecodeImageFromFile(context, nullptr, &image);
 	const AssetSuite::Result decodeNullMeshPathResult = AssetSuite::DecodeMeshFromFile(context, nullptr, &mesh);
+	const AssetSuite::Result getNullImageResult = AssetSuite::GetImageDesc(context, image, &imageDesc);
+	const AssetSuite::Result getNullMeshResult = AssetSuite::GetMeshDesc(context, mesh, &meshDesc);
+	const AssetSuite::Result releaseNullImageResult = AssetSuite::ReleaseImage(context, &image);
+	const AssetSuite::Result releaseNullMeshResult = AssetSuite::ReleaseMesh(context, &mesh);
 	const AssetSuite::Result releaseNullBlobResult = AssetSuite::ReleaseBlob(context, &blob);
 	const AssetSuite::Result destroyExplicitResult = AssetSuite::DestroyContext(&context);
 
@@ -182,6 +198,10 @@ int main()
 		loadNullPathResult == AssetSuite::Result::ErrorUnknown ||
 		decodeNullImagePathResult == AssetSuite::Result::ErrorUnknown ||
 		decodeNullMeshPathResult == AssetSuite::Result::ErrorUnknown ||
+		getNullImageResult == AssetSuite::Result::ErrorUnknown ||
+		getNullMeshResult == AssetSuite::Result::ErrorUnknown ||
+		releaseNullImageResult == AssetSuite::Result::ErrorUnknown ||
+		releaseNullMeshResult == AssetSuite::Result::ErrorUnknown ||
 		releaseNullBlobResult == AssetSuite::Result::ErrorUnknown ||
 		destroyExplicitResult == AssetSuite::Result::ErrorUnknown;
 }


### PR DESCRIPTION
## Summary

Implements issue #44 by wiring image and mesh decode entry points through shared runtime routing for both blob-backed and file-backed sources.

## What changed

- Added public `DecodeImage`, `DecodeImageFromFile`, `DecodeMesh`, and `DecodeMeshFromFile` API declarations.
- Added `Result::ErrorMalformedData` and documented decode error mapping.
- Added runtime-owned decoded image and mesh storage behind opaque handles.
- Routed blob decode through private `RuntimeContext` helpers using `CodecRegistry` probing.
- Implemented file decode wrappers over the same runtime decode path without persisting temporary blob handles.
- Added integration coverage for success, invalid/wrong-context handles, unsupported formats, file load failures, and malformed recognized BMP/OBJ data.
- Updated runtime and public docs for ownership, probing precedence, and temporary file blob behavior.

## Validation

- `Debug|x64` MSBuild compilation and linking reached `assetsuite_d.dll` successfully.
- Full solution verification is blocked in this Codex shell by environment PATH handling: the normal environment exposes duplicate `PATH`/`Path` keys to MSBuild, while the sanitized environment lets compilation/linking proceed but prevents post-build `powershell`/`xcopy` discovery.

Closes #44.