### PR TITLE
[AS2-E2-S6] Add diagnostics helpers for probe and decode failures

### DIFF
--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -4,6 +4,7 @@
 #include "AssetSuiteContext.h"
 
 #include "../runtime/AssetSuiteRuntime.h"
+#include "../runtime/AssetSuiteRuntimeDiagnostics.h"
 #include "../runtime/AssetSuiteRuntimeState.h"
 #include "../wavefront/ModelLoader.h"
 #include "../bmp/BmpDecoder.h"
@@ -182,7 +183,10 @@ AssetSuite::Result AssetSuite::LoadFile(ContextHandle context, const char* fileP
 	const Result mappedResult = MapFileLoadResult(loadResult);
 	if (mappedResult != Result::Success)
 	{
-		context->Runtime().Diagnostics().Add(loadResult, "Failed to load blob source file.");
+		context->Runtime().EmitDiagnostic(
+			loadResult,
+			LogLevel::Error,
+			Internal::Diagnostics::BlobLoadFailed);
 		return mappedResult;
 	}
 
@@ -246,7 +250,10 @@ AssetSuite::Result AssetSuite::DecodeImageFromFile(ContextHandle context, const 
 	const Result mappedResult = MapFileLoadResult(loadResult);
 	if (mappedResult != Result::Success)
 	{
-		context->Runtime().Diagnostics().Add(loadResult, "Failed to load image source file.");
+		context->Runtime().EmitDiagnostic(
+			loadResult,
+			LogLevel::Error,
+			Internal::Diagnostics::ImageLoadFailed);
 		return mappedResult;
 	}
 
@@ -308,7 +315,10 @@ AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const c
 	const Result mappedResult = MapFileLoadResult(loadResult);
 	if (mappedResult != Result::Success)
 	{
-		context->Runtime().Diagnostics().Add(loadResult, "Failed to load mesh source file.");
+		context->Runtime().EmitDiagnostic(
+			loadResult,
+			LogLevel::Error,
+			Internal::Diagnostics::MeshLoadFailed);
 		return mappedResult;
 	}
 

--- a/source/common/AssetSuite.cpp
+++ b/source/common/AssetSuite.cpp
@@ -260,6 +260,7 @@ AssetSuite::Result AssetSuite::DecodeImageFromFile(ContextHandle context, const 
 	try
 	{
 		Internal::Blob blob(std::move(rawBytes), Internal::MakeBlobSourceMetadata(filePath));
+		// DecodeImageBlob owns probe/decode diagnostics so this wrapper does not duplicate them.
 		return context->Runtime().DecodeImageBlob(blob, outImage);
 	}
 	catch (const std::bad_alloc&)
@@ -325,6 +326,7 @@ AssetSuite::Result AssetSuite::DecodeMeshFromFile(ContextHandle context, const c
 	try
 	{
 		Internal::Blob blob(std::move(rawBytes), Internal::MakeBlobSourceMetadata(filePath));
+		// DecodeMeshBlob owns probe/decode diagnostics so this wrapper does not duplicate them.
 		return context->Runtime().DecodeMeshBlob(blob, outMesh);
 	}
 	catch (const std::bad_alloc&)

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -1,4 +1,5 @@
 #include "AssetSuiteRuntime.h"
+#include "AssetSuiteRuntimeDiagnostics.h"
 
 #include <new>
 #include <utility>
@@ -158,20 +159,29 @@ AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeImageBlob(
 		static_cast<size_t>(blob.ByteSize()));
 	if (decoder == ImageDecoders::Auto)
 	{
-		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Image blob format is not supported.");
+		EmitDiagnostic(
+			ErrorCode::FileTypeNotSupported,
+			LogLevel::Warning,
+			Diagnostics::UnsupportedImageFormat);
 		return Result::ErrorUnsupportedFormat;
 	}
 
 	if (!HasMinimumImageDecodeBytes(decoder, blob))
 	{
-		Diagnostics().Add(ErrorCode::Undefined, "Image blob is too small for the selected decoder.");
+		EmitDiagnostic(
+			ErrorCode::Undefined,
+			LogLevel::Error,
+			Diagnostics::ImageBlobTooSmall);
 		return Result::ErrorMalformedData;
 	}
 
 	ImageDecoder* imageDecoder = CodecRegistry().FindImageDecoder(decoder);
 	if (!imageDecoder)
 	{
-		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Image decoder is not registered.");
+		EmitDiagnostic(
+			ErrorCode::FileTypeNotSupported,
+			LogLevel::Warning,
+			Diagnostics::ImageDecoderMissing);
 		return Result::ErrorUnsupportedFormat;
 	}
 
@@ -179,7 +189,10 @@ AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeImageBlob(
 	ImageDescriptor descriptor = {};
 	if (!imageDecoder->Decode(decodedBytes, const_cast<BYTE*>(reinterpret_cast<const BYTE*>(blob.Data())), descriptor))
 	{
-		Diagnostics().Add(ErrorCode::Undefined, "Image decoder rejected malformed data.");
+		EmitDiagnostic(
+			ErrorCode::Undefined,
+			LogLevel::Error,
+			Diagnostics::ImageDecodeRejected);
 		return MapSelectedDecoderFailure();
 	}
 
@@ -218,20 +231,29 @@ AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeMeshBlob(
 		static_cast<size_t>(blob.ByteSize()));
 	if (decoder == MeshDecoders::Auto)
 	{
-		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Mesh blob format is not supported.");
+		EmitDiagnostic(
+			ErrorCode::FileTypeNotSupported,
+			LogLevel::Warning,
+			Diagnostics::UnsupportedMeshFormat);
 		return Result::ErrorUnsupportedFormat;
 	}
 
 	if (!HasMinimumMeshDecodeBytes(decoder, blob))
 	{
-		Diagnostics().Add(ErrorCode::Undefined, "Mesh blob is too small for the selected decoder.");
+		EmitDiagnostic(
+			ErrorCode::Undefined,
+			LogLevel::Error,
+			Diagnostics::MeshBlobTooSmall);
 		return Result::ErrorMalformedData;
 	}
 
 	MeshDecoder* meshDecoder = CodecRegistry().FindMeshDecoder(decoder);
 	if (!meshDecoder)
 	{
-		Diagnostics().Add(ErrorCode::FileTypeNotSupported, "Mesh decoder is not registered.");
+		EmitDiagnostic(
+			ErrorCode::FileTypeNotSupported,
+			LogLevel::Warning,
+			Diagnostics::MeshDecoderMissing);
 		return Result::ErrorUnsupportedFormat;
 	}
 
@@ -242,7 +264,10 @@ AssetSuite::Result AssetSuite::Internal::RuntimeContext::DecodeMeshBlob(
 	MeshDescriptor descriptor = {};
 	if (!meshDecoder->Decode(decodedBytes, decodeBuffer.data(), descriptor))
 	{
-		Diagnostics().Add(ErrorCode::Undefined, "Mesh decoder rejected malformed data.");
+		EmitDiagnostic(
+			ErrorCode::Undefined,
+			LogLevel::Error,
+			Diagnostics::MeshDecodeRejected);
 		return MapSelectedDecoderFailure();
 	}
 

--- a/source/runtime/AssetSuiteRuntime.cpp
+++ b/source/runtime/AssetSuiteRuntime.cpp
@@ -294,3 +294,12 @@ void AssetSuite::Internal::RuntimeContext::DispatchLogEvent(LogLevel level, cons
 
 	logging.callback(level, message, logging.userData);
 }
+
+void AssetSuite::Internal::RuntimeContext::EmitDiagnostic(
+	ErrorCode code,
+	LogLevel level,
+	const char* message)
+{
+	Diagnostics().Add(code, message);
+	DispatchLogEvent(level, message);
+}

--- a/source/runtime/AssetSuiteRuntime.h
+++ b/source/runtime/AssetSuiteRuntime.h
@@ -36,6 +36,7 @@ namespace AssetSuite::Internal
 
 		void SetLoggingCallback(LoggingCallback callback, LogLevel minimumLevel, void* userData) noexcept;
 		void DispatchLogEvent(LogLevel level, const char* message) const;
+		void EmitDiagnostic(ErrorCode code, LogLevel level, const char* message);
 
 	private:
 		struct LoggingState

--- a/source/runtime/AssetSuiteRuntimeDiagnostics.h
+++ b/source/runtime/AssetSuiteRuntimeDiagnostics.h
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace AssetSuite::Internal::Diagnostics
+{
+	inline constexpr const char* UnsupportedImageFormat =
+		"ASSET_UNSUPPORTED_FORMAT: Image blob format is not supported.";
+	inline constexpr const char* ImageBlobTooSmall =
+		"ASSET_MALFORMED_DATA: Image blob is too small for the selected decoder.";
+	inline constexpr const char* ImageDecoderMissing =
+		"ASSET_UNSUPPORTED_FORMAT: Image decoder is not registered.";
+	inline constexpr const char* ImageDecodeRejected =
+		"ASSET_MALFORMED_DATA: Image decoder rejected malformed data.";
+
+	inline constexpr const char* UnsupportedMeshFormat =
+		"ASSET_UNSUPPORTED_FORMAT: Mesh blob format is not supported.";
+	inline constexpr const char* MeshBlobTooSmall =
+		"ASSET_MALFORMED_DATA: Mesh blob is too small for the selected decoder.";
+	inline constexpr const char* MeshDecoderMissing =
+		"ASSET_UNSUPPORTED_FORMAT: Mesh decoder is not registered.";
+	inline constexpr const char* MeshDecodeRejected =
+		"ASSET_MALFORMED_DATA: Mesh decoder rejected malformed data.";
+
+	inline constexpr const char* BlobLoadFailed =
+		"ASSET_FILE_LOAD_FAILED: Failed to load blob source file.";
+	inline constexpr const char* ImageLoadFailed =
+		"ASSET_FILE_LOAD_FAILED: Failed to load image source file.";
+	inline constexpr const char* MeshLoadFailed =
+		"ASSET_FILE_LOAD_FAILED: Failed to load mesh source file.";
+}

--- a/source/runtime/README.md
+++ b/source/runtime/README.md
@@ -67,6 +67,14 @@ persistent public `BlobHandle`.
 
 The public SDK adapter maps `NonExistingFile` to `Result::ErrorFileNotFound` and `IoFailure` to `Result::ErrorIoFailure`. Text-mode loads append a null terminator after successful reads; binary loads preserve the exact file bytes.
 
+## Diagnostics And Logging
+
+Runtime probe, decode, and file-load failures record private diagnostics and may emit one callback log event through the registered logging callback. Callback messages use stable internal `ASSET_*` prefixes, but diagnostic storage and runtime error details remain private implementation state.
+
+Decode-from-file wrappers own file-load diagnostics only. Once bytes are wrapped in a temporary blob, `DecodeImageBlob` and `DecodeMeshBlob` own probe/decode diagnostics so a single public failure path does not log the same failure twice.
+
+This story keeps cleanup scope limited to cleanup that occurs inside failed file/decode wrapper flows. Explicit invalid cleanup API calls such as failed `ReleaseBlob`, `ReleaseImage`, `ReleaseMesh`, and repeated `DestroyContext` validation remain non-logging paths unless a later story expands that behavior.
+
 ## Deferred Scope
 
 This runtime layer is intentionally foundational. The following work is deferred to later stories:

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -837,6 +837,7 @@ namespace GeneralUnitTests
 		TEST_METHOD(RuntimeDiagnosticsEmitFileLoadLogs)
 		{
 			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
 			AssetSuite::ImageHandle image = nullptr;
 			AssetSuite::MeshHandle mesh = nullptr;
 			LogCapture capture = {};
@@ -847,15 +848,21 @@ namespace GeneralUnitTests
 				AssetSuite::LogLevel::Error,
 				&capture));
 
-			Assert::AreEqual(true, AssetSuite::Result::ErrorFileNotFound == AssetSuite::DecodeImageFromFile(context, "missing_decode_image.bmp", &image));
+			Assert::AreEqual(true, AssetSuite::Result::ErrorFileNotFound == AssetSuite::LoadFile(context, "missing_blob_source.bin", &blob));
 			Assert::AreEqual(1, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
+			Assert::AreEqual(AssetSuite::Internal::Diagnostics::BlobLoadFailed, capture.lastMessage.c_str());
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorFileNotFound == AssetSuite::DecodeImageFromFile(context, "missing_decode_image.bmp", &image));
+			Assert::AreEqual(2, capture.callCount);
 			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
 			Assert::AreEqual(AssetSuite::Internal::Diagnostics::ImageLoadFailed, capture.lastMessage.c_str());
 
 			Assert::AreEqual(true, AssetSuite::Result::ErrorIoFailure == AssetSuite::DecodeMeshFromFile(context, std::filesystem::current_path().string().c_str(), &mesh));
-			Assert::AreEqual(2, capture.callCount);
+			Assert::AreEqual(3, capture.callCount);
 			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
 			Assert::AreEqual(AssetSuite::Internal::Diagnostics::MeshLoadFailed, capture.lastMessage.c_str());
+			Assert::IsNull(blob);
 			Assert::IsNull(image);
 			Assert::IsNull(mesh);
 

--- a/unit_tests/GeneralUnitTests.cpp
+++ b/unit_tests/GeneralUnitTests.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <fstream>
 #include <filesystem>
+#include <string>
 #include <utility>
 #include <vector>
 #include <Windows.h>
@@ -12,6 +13,7 @@
 #include "../source/common/AssetSuiteContext.h"
 #include "../source/runtime/AssetSuiteBlob.h"
 #include "../source/runtime/AssetSuiteRuntime.h"
+#include "../source/runtime/AssetSuiteRuntimeDiagnostics.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -374,7 +376,7 @@ namespace GeneralUnitTests
 
 			Assert::AreEqual(1, capture.callCount);
 			Assert::AreEqual(true, AssetSuite::LogLevel::Warning == capture.lastLevel);
-			Assert::AreEqual("registered", capture.lastMessage);
+			Assert::AreEqual("registered", capture.lastMessage.c_str());
 			Assert::IsTrue(&capture == capture.lastUserData);
 
 			DestroyContextForCleanup(context);
@@ -397,7 +399,7 @@ namespace GeneralUnitTests
 
 			Assert::AreEqual(2, capture.callCount);
 			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
-			Assert::AreEqual("error", capture.lastMessage);
+			Assert::AreEqual("error", capture.lastMessage.c_str());
 
 			DestroyContextForCleanup(context);
 		}
@@ -427,7 +429,7 @@ namespace GeneralUnitTests
 
 			Assert::AreEqual(0, firstCapture.callCount);
 			Assert::AreEqual(1, secondCapture.callCount);
-			Assert::AreEqual("replacement", secondCapture.lastMessage);
+			Assert::AreEqual("replacement", secondCapture.lastMessage.c_str());
 			Assert::IsTrue(&secondCapture == secondCapture.lastUserData);
 
 			DestroyContextForCleanup(context);
@@ -796,6 +798,130 @@ namespace GeneralUnitTests
 			DestroyContextForCleanup(context);
 		}
 
+		TEST_METHOD(RuntimeDiagnosticsEmitUnsupportedDecodeLogs)
+		{
+			const std::filesystem::path unsupportedPath = "unsupported_decode_payload.asset";
+			WriteBinaryFile(unsupportedPath, { 0x10, 0x20, 0x30, 0x40 });
+
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle blob = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			AssetSuite::MeshHandle mesh = nullptr;
+			LogCapture capture = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Warning,
+				&capture));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, unsupportedPath.string().c_str(), &blob));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorUnsupportedFormat == AssetSuite::DecodeImage(context, blob, &image));
+			Assert::AreEqual(1, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Warning == capture.lastLevel);
+			Assert::AreEqual(AssetSuite::Internal::Diagnostics::UnsupportedImageFormat, capture.lastMessage.c_str());
+			Assert::IsTrue(&capture == capture.lastUserData);
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorUnsupportedFormat == AssetSuite::DecodeMesh(context, blob, &mesh));
+			Assert::AreEqual(2, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Warning == capture.lastLevel);
+			Assert::AreEqual(AssetSuite::Internal::Diagnostics::UnsupportedMeshFormat, capture.lastMessage.c_str());
+			Assert::IsNull(image);
+			Assert::IsNull(mesh);
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &blob));
+			DestroyContextForCleanup(context);
+			std::filesystem::remove(unsupportedPath);
+		}
+
+		TEST_METHOD(RuntimeDiagnosticsEmitFileLoadLogs)
+		{
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			AssetSuite::MeshHandle mesh = nullptr;
+			LogCapture capture = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Error,
+				&capture));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorFileNotFound == AssetSuite::DecodeImageFromFile(context, "missing_decode_image.bmp", &image));
+			Assert::AreEqual(1, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
+			Assert::AreEqual(AssetSuite::Internal::Diagnostics::ImageLoadFailed, capture.lastMessage.c_str());
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorIoFailure == AssetSuite::DecodeMeshFromFile(context, std::filesystem::current_path().string().c_str(), &mesh));
+			Assert::AreEqual(2, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
+			Assert::AreEqual(AssetSuite::Internal::Diagnostics::MeshLoadFailed, capture.lastMessage.c_str());
+			Assert::IsNull(image);
+			Assert::IsNull(mesh);
+
+			DestroyContextForCleanup(context);
+		}
+
+		TEST_METHOD(RuntimeDiagnosticsRespectLogLevelFiltering)
+		{
+			const std::filesystem::path unsupportedPath = "filtered_decode_payload.asset";
+			const std::filesystem::path malformedImagePath = "filtered_malformed_decode_image.bmp";
+			WriteBinaryFile(unsupportedPath, { 0x10, 0x20, 0x30, 0x40 });
+			WriteBinaryFile(malformedImagePath, { 'B', 'M' });
+
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::BlobHandle unsupportedBlob = nullptr;
+			AssetSuite::BlobHandle malformedBlob = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			LogCapture capture = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Error,
+				&capture));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, unsupportedPath.string().c_str(), &unsupportedBlob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::LoadFile(context, malformedImagePath.string().c_str(), &malformedBlob));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorUnsupportedFormat == AssetSuite::DecodeImage(context, unsupportedBlob, &image));
+			Assert::AreEqual(0, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::Result::ErrorMalformedData == AssetSuite::DecodeImage(context, malformedBlob, &image));
+			Assert::AreEqual(1, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
+			Assert::AreEqual(AssetSuite::Internal::Diagnostics::ImageBlobTooSmall, capture.lastMessage.c_str());
+
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &malformedBlob));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::ReleaseBlob(context, &unsupportedBlob));
+			DestroyContextForCleanup(context);
+			std::filesystem::remove(malformedImagePath);
+			std::filesystem::remove(unsupportedPath);
+		}
+
+		TEST_METHOD(RuntimeDiagnosticsLogDecodeFromFileFailureOnce)
+		{
+			const std::filesystem::path malformedImagePath = "single_log_malformed_decode_image.bmp";
+			WriteBinaryFile(malformedImagePath, { 'B', 'M' });
+
+			AssetSuite::ContextHandle context = nullptr;
+			AssetSuite::ImageHandle image = nullptr;
+			LogCapture capture = {};
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::CreateContext(nullptr, &context));
+			Assert::AreEqual(true, AssetSuite::Result::Success == AssetSuite::SetLoggingCallback(
+				context,
+				&CaptureLogEvent,
+				AssetSuite::LogLevel::Trace,
+				&capture));
+
+			Assert::AreEqual(true, AssetSuite::Result::ErrorMalformedData == AssetSuite::DecodeImageFromFile(context, malformedImagePath.string().c_str(), &image));
+			Assert::AreEqual(1, capture.callCount);
+			Assert::AreEqual(true, AssetSuite::LogLevel::Error == capture.lastLevel);
+			Assert::AreEqual(AssetSuite::Internal::Diagnostics::ImageBlobTooSmall, capture.lastMessage.c_str());
+			Assert::IsNull(image);
+
+			DestroyContextForCleanup(context);
+			std::filesystem::remove(malformedImagePath);
+		}
+
 		TEST_METHOD(DecodeImageMapsMalformedRecognizedDataConsistently)
 		{
 			const std::filesystem::path malformedImagePath = "malformed_decode_image.bmp";
@@ -1071,7 +1197,7 @@ namespace GeneralUnitTests
 		{
 			int callCount;
 			AssetSuite::LogLevel lastLevel;
-			const char* lastMessage;
+			std::string lastMessage;
 			void* lastUserData;
 		};
 
@@ -1094,7 +1220,7 @@ namespace GeneralUnitTests
 			auto* capture = static_cast<LogCapture*>(userData);
 			++capture->callCount;
 			capture->lastLevel = level;
-			capture->lastMessage = message;
+			capture->lastMessage = message ? message : "";
 			capture->lastUserData = userData;
 		}
 	};


### PR DESCRIPTION
## Summary

- Added private runtime diagnostic message constants with stable `ASSET_*` callback prefixes.
- Added a centralized runtime helper that records internal diagnostics and emits filtered log callback events.
- Routed probe, decode, and file-load failure paths through the helper while preserving existing public `Result` mappings.
- Documented diagnostic ownership and cleanup-path scope to avoid duplicate log spam.
- Added focused unit coverage for callback emission, log-level filtering, and single emission from decode-from-file failures.

## Validation

- Debug build passed with MSBuild.
- Debug unit tests passed: 176/176.
- Debug public header validation passed.
- Release build passed with MSBuild.
- Release unit tests passed: 176/176.
- Release public header validation passed.

Closes #45.